### PR TITLE
feat: session management redesign

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,6 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
-        // フォルダパスは --extensionDevelopmentPath より前に置く。
-        // VSCode CLI は最初の非フラグ引数をワークスペースとして開く。
-        // ref: https://github.com/microsoft/vscode/blob/main/.vscode/launch.json
-        "${workspaceFolder}",
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": ["${workspaceFolder}/out/**/*.js"],

--- a/docs/planning/2026-03-01-session-redesign.md
+++ b/docs/planning/2026-03-01-session-redesign.md
@@ -1,0 +1,471 @@
+# セッション管理の再設計
+
+## 経緯
+
+### なぜ再設計するか
+
+初期実装（#4）は「動くものを先に作る」方針で、以下の仮定に基づいていた:
+
+1. `fs.watch` で `~/.claude/projects/<slug>/` を監視し、新しい `.jsonl` ファイルの出現でセッション作成を検知
+2. `pendingTerminals` FIFO キューで「最近作ったターミナル」と「新しく出現したセッション」を紐付け
+3. `onDidCloseTerminal` でセッション記録を削除
+
+Issue #5, #6, #7 の調査で以下が判明し、これらの仮定がすべて破綻:
+
+| 仮定 | 事実 | 出典 |
+|------|------|------|
+| slug は `path.toLowerCase().replace(/[:\\/]/g, "-")` | CLI は `path.replace(/[^a-zA-Z0-9]/g, "-")`（toLowerCase なし） | #5 comment 1 |
+| FIFO で紐付ければ正しい | 2つのターミナルを素早く作ると逆順にマッチする可能性 | コードレビュー |
+| ターミナル閉じたら記録削除 | 閉じた後に復元するのが目的なので、削除したら意味がない | #7 MoSCoW |
+| `deactivate()` で状態を保存 | PC 再起動・クラッシュ時に呼ばれない | #7 VSCode ライフサイクル調査 |
+| fs.watch は信頼できる | プラットフォーム差異、ネットワークドライブ問題、タイミング問題 | #6 Terminal API 調査 |
+
+### 新しいアプローチの着想
+
+調査中に `claude --session-id <uuid>` フラグの存在を確認（CLI ヘルプで実証済み）。
+これにより:
+
+- **拡張側で UUID を生成** → `claude --session-id <uuid>` でセッション作成
+- セッション ID は**ターミナル作成前に確定**
+- `fs.watch` も `pendingTerminals` も**不要**
+
+---
+
+## 要件の再確認
+
+> 今開いているワークスペースに対応する Claude Code セッションを一覧表示し、ワンクリックで再開する。
+
+### Must Have（v1）
+
+1. 現在ワークスペースのセッション一覧表示
+2. セッション再開（`claude --resume <id>`）
+3. VSCode 再起動後のセッション情報保持
+4. 新セッション作成と即時追跡
+5. Windows CWD ケース対応
+
+### Should Have
+
+6. セッションの表示名（最初のユーザー入力）
+7. 「最新セッションを続行」ショートカット（`claude --continue`）
+8. アクティブ/非アクティブ状態の区別
+
+### Won't Have（v1 スコープ外）
+
+- ターミナル出力の復元（VSCode API 制約で不可能）
+- 全プロジェクト横断の resume（ワークスペース単位で十分）
+- Claude Code SDK の直接呼び出し
+
+---
+
+## ユーザーストーリー
+
+### 得られる UX
+
+**朝、VSCode を開く。**
+昨夜 VSCode がクラッシュして中断された2つのセッションが、自動的にターミナルで再開される。`claude --resume ...` が走り、昨夜の会話の続きからそのまま作業できる。ステータスバーには `$(terminal) Claude: 2 sessions` と表示されている。
+
+**作業中、新しいセッションを始める。**
+Quick Pick から "New Session" を選ぶ。ターミナルが開き、Claude が起動する。裏では拡張が UUID を発行して `claude --session-id` で起動しているが、ユーザーには見えない。
+
+**セッションが終わった。**
+Claude に `/exit` と打つ。CLI が終了する。Quick Pick を開くと Completed 欄に `✓` 付きで残っている。邪魔にはならないが、過去の作業が見える。必要なら選んで再開もできる。
+
+**ターミナルを手で閉じた。**
+ターミナルタブの × ボタンで閉じた。でもセッション自体は消えない。Quick Pick を開けば Resumable 欄にいる。必要になったらいつでも再開できる。
+
+**昨日ターミナルで直接 `claude` を叩いた。**
+拡張を経由しなかったセッションも、Quick Pick を開けば見つかる。history.jsonl から自動で発見される。
+
+### 得られない UX
+
+**ターミナルの出力は戻ってこない。**
+セッションを再開しても、前回のターミナルに表示されていたテキスト（コード差分、エラーメッセージ等）は復元されない。VSCode Terminal API の制約で不可能。Claude の会話履歴は CLI 側が保持しているので、Claude 自身は前回の文脈を覚えている。
+
+**別プロジェクトのセッションは見えない。**
+quantum-scribe を開いているとき、MathDesk のセッションは表示されない。プロジェクトごとにウィンドウが分かれる前提。
+
+**過去のセッション一覧は無限には伸びない。**
+Quick Pick に表示するセッションは最新 N 件に制限される。古いセッションを再開したければ `claude --resume` をターミナルで直接叩く。
+
+---
+
+## 設計
+
+### アーキテクチャ変更の概要
+
+```mermaid
+graph TD
+    subgraph "現行（廃止）"
+        A1[pendingTerminals FIFO] --> A2[fs.watch]
+        A2 --> A3[onNewSession callback]
+        A3 --> A4[store.upsert]
+        A5[onDidCloseTerminal] --> A6[store.remove ❌]
+    end
+
+    subgraph "新設計"
+        B1["UUID 生成"] --> B2["claude --session-id uuid"]
+        B1 --> B3["globalState に即時保存"]
+        B4["history.jsonl 読み取り"] --> B5["セッション発見"]
+        B6["onDidCloseTerminal"] --> B7["markInactive（削除しない）"]
+    end
+```
+
+### セッションのライフサイクル
+
+```mermaid
+flowchart TB
+    subgraph birth ["セッションの誕生"]
+        direction LR
+        B1["拡張が New Session 実行\nUUID 生成\n--session-id で CLI 起動"]
+        B2["ユーザーがターミナルで\n直接 claude 実行"]
+        B3["サブエージェント\nparent/subagents/agent-*.jsonl"]
+    end
+
+    subgraph tracked ["拡張が追跡 -- globalState"]
+        Active["ACTIVE\nターミナルが開いている"]
+        Inactive["INACTIVE\nターミナル閉じた\nQuick Pick に残る"]
+        Completed["COMPLETED\nCLI が正常終了\n表示しない"]
+
+        Active -- "exitStatus.reason = User\nターミナルを閉じた" --> Inactive
+        Active -- "exitStatus.reason = Process\nCLI が exit で終了" --> Completed
+        Inactive -- "Quick Pick で resume" --> Active
+    end
+
+    subgraph display ["表示のみ -- history.jsonl"]
+        Resumable["RESUMABLE\n探せば見つかる"]
+    end
+
+    OutOfScope["スコープ外\n拡張は関与しない"]
+
+    B1 -- "globalState に即時保存" --> Active
+    B2 -- "次回 activate 時に\nhistory.jsonl から発見" --> Resumable
+    B3 --> OutOfScope
+    Resumable -- "resume 選択時\ntracked に昇格" --> Active
+
+    subgraph restart ["VSCode 再起動"]
+        StillActive["globalState に\nACTIVE のまま残る"]
+    end
+
+    Active -. "VSCode が死ぬ\nonDidCloseTerminal 発火しない" .-> StillActive
+    StillActive -- "自動復元プロンプト" --> Active
+```
+
+### 状態ごとの振る舞い
+
+| 状態 | 自動復元 | Quick Pick 表示 | 態度 |
+|------|---------|----------------|------|
+| active（VSCode 再起動で残った） | する | `●` Active 欄 | プロアクティブに復元を提案 |
+| inactive（ターミナルを閉じた） | **しない** | `○` Resumable 欄 | パッシブ — 探せば見つかる |
+| completed（CLI が exit で終了） | しない | `✓` Completed 欄 | 見えるが邪魔しない。選べば再開可能 |
+| resumable（history.jsonl 由来） | しない | `○` Resumable 欄 | パッシブ — 探せば見つかる |
+
+### データソースの役割
+
+```mermaid
+flowchart LR
+    subgraph sources ["データソース"]
+        GS["globalState\nSessionStore"]
+        HJ["history.jsonl\nCLI が書く"]
+    end
+
+    subgraph sessions ["セッション種別"]
+        T["拡張が作成\ntracked"]
+        D["拡張外で作成\ndisplay-only"]
+    end
+
+    subgraph ui ["UI"]
+        QP["Quick Pick メニュー"]
+    end
+
+    GS -- "読み書き" --> T
+    HJ -- "読み取り専用" --> D
+    T --> QP
+    D --> QP
+    QP -- "resume 選択時\ndisplay-only が tracked に昇格" --> GS
+```
+
+### セッション発見（既存セッションの検出）
+
+**方法**: `history.jsonl` を読み、`project` フィールドとワークスペースパスを case-insensitive 比較。
+
+```
+history.jsonl の各行:
+  { "project": "C:\\dev\\quantum-scribe", "sessionId": "abc-123", "display": "やあ", "timestamp": ... }
+
+ワークスペースパス: "c:\\dev\\quantum-scribe"
+
+normalize("C:\\dev\\quantum-scribe") === normalize("c:\\dev\\quantum-scribe")
+→ マッチ → sessionId "abc-123" はこのプロジェクトのセッション
+```
+
+**利点**:
+- slug 生成が不要（`project` は元のフルパス）
+- case-insensitive 比較で Windows のケース問題を回避
+- CLI のバージョンアップで slug 実装が変わっても影響しない
+
+**パフォーマンス**: history.jsonl は一度読んでキャッシュ。ファイルサイズは現在 867 行で十分小さい。
+
+### 新セッション作成
+
+```typescript
+// 1. UUID を生成
+const sessionId = crypto.randomUUID();
+
+// 2. globalState に即座に保存
+store.upsert({
+  terminalName: `Claude #${nextNumber}`,
+  sessionId,
+  projectPath: workspacePath,
+  lastSeen: Date.now(),
+  status: "active",
+});
+
+// 3. ターミナル作成 + コマンド送信
+const terminal = vscode.window.createTerminal({ name: `Claude #${nextNumber}` });
+terminal.sendText(`claude --session-id ${sessionId}`);
+```
+
+**順序が重要**: 保存 → ターミナル作成。ターミナル作成中にクラッシュしても、セッション ID は保持される。
+
+### セッション再開
+
+```typescript
+const terminal = vscode.window.createTerminal({ name: `Claude: ${displayName}` });
+terminal.sendText(`claude --resume ${sessionId}`);
+
+store.upsert({
+  ...existingMapping,
+  terminalName: terminal.name,
+  lastSeen: Date.now(),
+  status: "active",
+});
+```
+
+### ターミナル終了時
+
+```typescript
+vscode.window.onDidCloseTerminal((terminal) => {
+  const reason = terminal.exitStatus?.reason;
+
+  if (reason === vscode.TerminalExitReason.Process) {
+    // CLI が自分で終了（exit, /exit 等）→ 完了
+    store.markCompleted(terminal.name, projectPath);
+  } else {
+    // ユーザーがターミナルを閉じた、または不明 → 復元候補
+    store.markInactive(terminal.name, projectPath);
+  }
+  updateStatusBar();
+});
+```
+
+### ステータスバー表示
+
+- `$(terminal) Claude: 3 sessions` — 発見された全セッション数
+- クリック → Quick Pick メニュー
+
+### Quick Pick メニュー
+
+```
+━━━ Active ━━━
+  ● Claude #1 — 「このコードを...」 (2m ago)
+  ● Claude #2 — 「テストを追加...」 (5m ago)
+━━━ Resumable ━━━
+  ○ 「リファクタリング...」 (3h ago)     ← inactive: ターミナルを閉じた
+  ○ 「バグ修正の調査...」 (1d ago)      ← history.jsonl から発見
+━━━ Completed ━━━
+  ✓ 「テスト追加」 (1d ago)             ← CLI が exit で正常終了
+  ✓ 「初期セットアップ」 (3d ago)
+━━━ Actions ━━━
+  + New Session
+  ↻ Continue Last (claude --continue)
+```
+
+全状態のセッションが Quick Pick に表示される。アイコンと欄で区別。completed を選んでも resume 可能。
+
+---
+
+## ファイル別の変更内容
+
+### claude-dir.ts → 大幅変更
+
+**廃止**:
+- `projectPathToSlug()` — slug 生成自体が不要に（history.jsonl ベースで発見）
+- `watchProjectDir()` — fs.watch 不要に
+- `getSessionDisplayName()` — 非効率な逐次検索
+
+**新規**:
+- `discoverSessions(workspacePath)` — history.jsonl を読み、ワークスペースに対応するセッション一覧を返す
+- `readHistoryEntries()` — history.jsonl のパースとキャッシュ
+- `normalizePath(path)` — case-insensitive パス比較用
+
+**残存**:
+- `getClaudeDir()` — そのまま
+- `listSessionIds()` — フォールバック用に残す（history.jsonl に記録がない古いセッションの発見）
+
+### session-store.ts → 中程度の変更
+
+**変更**:
+- `SessionMapping` に `status: "active" | "inactive" | "completed"` フィールド追加
+- `remove()` → `markInactive()` / `markCompleted()` に分割
+- `getRestorable()` — inactive かつ TTL 内のセッションを返す（completed は含めない）
+
+**新規**:
+- `merge(discovered)` — 発見されたセッションと既存マッピングの統合
+
+### extension.ts → 大幅変更
+
+**廃止**:
+- `pendingTerminals` 配列
+- `fs.watch` 関連コード
+- `onDidCloseTerminal` → `store.remove()`
+
+**変更**:
+- `startNewSession()` — `--session-id <uuid>` を使用
+- `showQuickPick()` — active/inactive 分類、continue last オプション
+- `activate()` — 起動時に `discoverSessions()` + `store.merge()` で一覧構築
+- `onDidCloseTerminal` — `store.markInactive()` を呼ぶ
+
+### types.ts → minor 追加
+
+```typescript
+export interface SessionMapping {
+  terminalName: string;
+  sessionId: string;
+  projectPath: string;
+  lastSeen: number;
+  firstPrompt?: string;
+  status: "active" | "inactive" | "completed";  // 追加
+}
+```
+
+---
+
+## 実装フェーズ
+
+### Phase 0: `--session-id` 検証（ブロッカー）
+
+全設計が `--session-id` フラグに依存するため、実装前に手動検証する:
+
+```bash
+claude --session-id 550e8400-e29b-41d4-a716-446655440000
+```
+
+検証項目:
+- [ ] セッションが作成されるか
+- [ ] `.jsonl` ファイル名が指定した UUID になるか
+- [ ] `history.jsonl` の `sessionId` が指定した UUID と一致するか
+- [ ] `history.jsonl` の `project` フィールドに CWD が正しく記録されるか
+- [ ] 既存 UUID を指定した場合の挙動（エラー or 既存セッション接続）
+
+**判断**: 検証 OK → Phase 1 へ / NG → 設計見直し
+
+### Phase 1: データ層（claude-dir.ts + types.ts）
+
+1. `types.ts` に `status` フィールド追加
+2. `normalizePath()` を共有ユーティリティとして切り出し（`session-store.ts` の既存実装と統合）
+3. `discoverSessions()` 実装（history.jsonl 読み取り + パス比較）
+4. `readHistoryEntries()` 実装（パース + キャッシュ）
+5. `watchProjectDir()`, `projectPathToSlug()`, `getSessionDisplayName()`, `listSessionIds()` 廃止
+6. テスト追加
+
+`listSessionIds()` は廃止する。フォールバックとして残す案もあったが、slug 生成の修正が必要になり複雑さが増すだけなので、history.jsonl 一本に絞る。history.jsonl に記録がないセッション（ユーザー入力なし）は復元する価値もない。
+
+### Phase 2: ストア層（session-store.ts）
+
+1. `remove()` → `markInactive()` / `markCompleted()` に分割
+2. `markCompleted` は以降の `markInactive` で上書きされない保護（completed は終端状態）
+3. `getRestorable()` を inactive かつ TTL 内に限定
+4. `fromState()` でデシリアライズ時の `status` 欠損補完: `status ?? "inactive"`
+5. `status` フィールドの既存テスト更新 + 新規テスト追加
+
+`merge()` は作らない。データソースの役割を明確に分離する:
+- **globalState**（SessionStore）: 拡張が作成・追跡したセッションの権威ソース。書き込み可能。
+- **history.jsonl**（discoverSessions）: CLI が記録したセッションの読み取り専用参照。表示用。
+
+`activate()` 時に両方を読み、UI に統合して表示する。永続化は globalState のみ。
+
+### Phase 3: UI 層（extension.ts）
+
+1. `pendingTerminals` 廃止
+2. `startNewSession()` を `--session-id` 方式に変更
+3. `onDidCloseTerminal` で `exitStatus.reason` を見て `markInactive` / `markCompleted` を分岐
+4. `activate()` で `discoverSessions()` 呼び出し + globalState 読み出し → 統合表示
+5. `autoRestoreSessions()` を globalState に active のまま残ったセッションのみ対象に修正（VSCode 再起動時のみ発動）
+6. `claudeResurrect.resumeAll` コマンド廃止 → Quick Pick の "Continue Last" に置換
+7. Quick Pick UI 更新（active/inactive/completed 3欄分類）
+8. `autoRestore` 設定の説明文更新（セマンティクス変更: 全セッション → VSCode 再起動で中断された active セッションのみ）
+9. テスト更新
+
+### 🔍 確認ターン: Phase 1 完了時
+
+**レビュー内容**:
+- [ ] `discoverSessions()` が正しくセッションを発見するか
+- [ ] テストが通るか（`npm run test`）
+- [ ] history.jsonl の実データで動作するか
+
+**判断**: Go / 修正 / 中止
+
+---
+
+## リスク
+
+| リスク | 影響 | 対策 |
+|--------|------|------|
+| `--session-id` の挙動が想定と異なる | 設計全体が崩壊 | **Phase 0 で検証（ブロッカー）** |
+| history.jsonl のフォーマットが CLI アップデートで変更 | セッション発見が壊れる | 構造検証 + エラー時の graceful degradation |
+| history.jsonl が巨大になった場合 | 起動が遅くなる | 末尾から N 行だけ読む、またはタイムスタンプフィルタ |
+| resume 時に session ID が変わるバグ (#12235) | 追跡が途切れる | resume 後の新 ID は追跡不要（元 ID のファイルに追記される） |
+| 既存 globalState に status フィールドがない | ランタイム undefined | `fromState()` でデシリアライズ時に `status ?? "inactive"` で補完 |
+
+## 複雑度: 中
+
+3ファイルの大幅変更だが、各変更は独立しており段階的に検証可能。
+
+---
+
+## 批評レビュー結果
+
+### 第1回レビュー（計画初版）
+
+| 指摘 | 対応 |
+|------|------|
+| `--session-id` 検証がリスク表の注釈に留まっている | Phase 0 としてブロッカータスクに昇格 |
+| 既存 globalState の status 欠損 | Phase 2 に `fromState()` での補完ロジック追加 |
+| `merge()` の仕様が不明確 | merge() を廃止。globalState = 書き込み、history.jsonl = 読み取りの分離に変更 |
+| `autoRestoreSessions` の扱いが不明 | Phase 3 に明記（active のみ対象、VSCode 再起動時のみ発動） |
+| `resumeAll` コマンドの扱いが不明 | Phase 3 で廃止 → Quick Pick の "Continue Last" に置換と明記 |
+| `normalizePath` が 2 ファイルに重複 | Phase 1 で共有ユーティリティに統合 |
+| `listSessionIds()` フォールバックの slug バグ | フォールバック自体を廃止（history.jsonl 一本化） |
+
+### 第2回レビュー（3状態ライフサイクル導入後）
+
+| 指摘 | 対応 |
+|------|------|
+| completed が history.jsonl から幽霊復活する | completed も Quick Pick に表示する方針に変更。除外ロジック不要に |
+| Phase 0 に history.jsonl の project フィールド検証が欠けている | Phase 0 チェックリストに追加 |
+| completed → inactive への退行競合 | Phase 2 に「completed は終端状態、markInactive で上書きしない」保護を追加 |
+| `autoRestore` 設定のセマンティクス変更が breaking change | Phase 3 に設定説明文の更新を追加 |
+| `Extension` 終了理由が暗黙的に inactive 扱い | 意図的。コードコメントで明示する（Phase 3） |
+| Quick Pick の history.jsonl 由来セッション件数上限が未定 | ユーザーストーリーに「最新 N 件制限」として明記 |
+
+---
+
+## F5 手動テスト手順
+
+Extension Development Host はワークスペースなしで起動する。
+拡張は `vscode.workspace.workspaceFolders` に依存するため、テスト前にフォルダを開く必要がある。
+
+**制約**: VSCode はフォルダを排他的に握る。他のインスタンスで開いているフォルダは選べない。
+テスト用に他で開いていないフォルダを使うこと。
+
+### 手順
+
+1. F5 で Extension Development Host を起動
+2. **フォルダを開く**（「ようこそ」画面 → 「フォルダーを開く」で、他の VSCode で開いていないフォルダを選ぶ）
+3. ステータスバー右側に `Claude: N sessions` が表示されることを確認
+4. ステータスバーをクリック → Quick Pick が開く
+   - 「Actions」セクションに「New Session」「Continue Last」がある
+   - history.jsonl にそのプロジェクトの履歴があれば「Resumable」セクションにも表示される
+5. 「New Session」選択 → ターミナルが開き `claude --session-id <uuid>` が実行される
+6. ターミナルの × ボタンで閉じる → ステータスバーのカウントが変わる（inactive に遷移）
+7. もう一度 Quick Pick を開く → さっきのセッションが「Resumable」に表示される

--- a/package.json
+++ b/package.json
@@ -26,10 +26,6 @@
         "title": "Claude Resurrect: New Session"
       },
       {
-        "command": "claudeResurrect.resumeAll",
-        "title": "Claude Resurrect: Resume All Sessions"
-      },
-      {
         "command": "claudeResurrect.showMenu",
         "title": "Claude Resurrect: Show Menu"
       }

--- a/src/claude-dir.test.ts
+++ b/src/claude-dir.test.ts
@@ -1,28 +1,123 @@
-import { describe, it, expect } from "vitest";
-import { projectPathToSlug } from "./claude-dir";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 
-describe("projectPathToSlug", () => {
-  it("converts Windows path", () => {
-    expect(projectPathToSlug("C:\\dev\\quantum-scribe")).toBe(
-      "c--dev-quantum-scribe",
-    );
+vi.mock("node:fs");
+vi.mock("node:os", () => ({
+  homedir: vi.fn(() => "/home/testuser"),
+}));
+
+import { discoverSessions, readHistoryEntries, getClaudeDir } from "./claude-dir";
+
+describe("getClaudeDir", () => {
+  it("returns ~/.claude", () => {
+    expect(getClaudeDir()).toBe(path.join("/home/testuser", ".claude"));
+  });
+});
+
+describe("readHistoryEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("converts Unix path", () => {
-    expect(projectPathToSlug("/home/user/project")).toBe(
-      "-home-user-project",
-    );
+  it("returns empty array when file does not exist", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    expect(readHistoryEntries()).toEqual([]);
   });
 
-  it("handles drive letter", () => {
-    expect(projectPathToSlug("D:\\workspace\\app")).toBe(
-      "d--workspace-app",
+  it("parses valid JSONL lines", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      [
+        JSON.stringify({ display: "hello", pastedContents: {}, timestamp: 1000, project: "C:\\dev\\foo", sessionId: "aaa" }),
+        JSON.stringify({ display: "world", pastedContents: {}, timestamp: 2000, project: "C:\\dev\\foo", sessionId: "bbb" }),
+      ].join("\n"),
     );
+
+    const entries = readHistoryEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].display).toBe("hello");
+    expect(entries[1].sessionId).toBe("bbb");
   });
 
-  it("is case-insensitive", () => {
-    expect(projectPathToSlug("C:\\Dev\\MyProject")).toBe(
-      "c--dev-myproject",
+  it("skips malformed lines", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      [
+        JSON.stringify({ display: "good", pastedContents: {}, timestamp: 1000, project: "C:\\dev\\foo", sessionId: "aaa" }),
+        "not json {{{",
+        JSON.stringify({ display: "also good", pastedContents: {}, timestamp: 2000, project: "C:\\dev\\foo", sessionId: "bbb" }),
+      ].join("\n"),
     );
+
+    const entries = readHistoryEntries();
+    expect(entries).toHaveLength(2);
+  });
+});
+
+describe("discoverSessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array when no history file", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    expect(discoverSessions("C:\\dev\\foo")).toEqual([]);
+  });
+
+  it("filters sessions by project path (case-insensitive)", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      [
+        JSON.stringify({ display: "match", pastedContents: {}, timestamp: 1000, project: "C:\\dev\\my-project", sessionId: "aaa" }),
+        JSON.stringify({ display: "no match", pastedContents: {}, timestamp: 2000, project: "C:\\dev\\other", sessionId: "bbb" }),
+        JSON.stringify({ display: "case match", pastedContents: {}, timestamp: 3000, project: "c:\\dev\\My-Project", sessionId: "ccc" }),
+      ].join("\n"),
+    );
+
+    const sessions = discoverSessions("C:\\dev\\my-project");
+    expect(sessions).toHaveLength(2);
+    expect(sessions.map((s) => s.sessionId)).toEqual(["ccc", "aaa"]);
+  });
+
+  it("deduplicates by sessionId and keeps latest timestamp", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      [
+        JSON.stringify({ display: "first msg", pastedContents: {}, timestamp: 1000, project: "C:\\dev\\foo", sessionId: "aaa" }),
+        JSON.stringify({ display: "second msg", pastedContents: {}, timestamp: 5000, project: "C:\\dev\\foo", sessionId: "aaa" }),
+        JSON.stringify({ display: "third msg", pastedContents: {}, timestamp: 3000, project: "C:\\dev\\foo", sessionId: "aaa" }),
+      ].join("\n"),
+    );
+
+    const sessions = discoverSessions("C:\\dev\\foo");
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].firstPrompt).toBe("first msg");
+    expect(sessions[0].lastSeen).toBe(5000);
+  });
+
+  it("sorts by lastSeen descending", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      [
+        JSON.stringify({ display: "old", pastedContents: {}, timestamp: 1000, project: "C:\\dev\\foo", sessionId: "old-id" }),
+        JSON.stringify({ display: "new", pastedContents: {}, timestamp: 9000, project: "C:\\dev\\foo", sessionId: "new-id" }),
+        JSON.stringify({ display: "mid", pastedContents: {}, timestamp: 5000, project: "C:\\dev\\foo", sessionId: "mid-id" }),
+      ].join("\n"),
+    );
+
+    const sessions = discoverSessions("C:\\dev\\foo");
+    expect(sessions.map((s) => s.sessionId)).toEqual(["new-id", "mid-id", "old-id"]);
+  });
+
+  it("normalizes Windows backslash vs forward slash", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ display: "hi", pastedContents: {}, timestamp: 1000, project: "C:\\dev\\foo", sessionId: "aaa" }),
+    );
+
+    const sessions = discoverSessions("C:/dev/foo");
+    expect(sessions).toHaveLength(1);
   });
 });

--- a/src/claude-dir.ts
+++ b/src/claude-dir.ts
@@ -2,128 +2,86 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import type { HistoryEntry } from "./types";
+import { normalizePath } from "./normalize-path";
 
 /** Resolve the ~/.claude directory */
 export function getClaudeDir(): string {
   return path.join(os.homedir(), ".claude");
 }
 
-/**
- * Convert a project path to the slug used in ~/.claude/projects/.
- * e.g. "C:\dev\quantum-scribe" → "c--dev-quantum-scribe"
- */
-export function projectPathToSlug(projectPath: string): string {
-  return projectPath
-    .toLowerCase()
-    .replace(/[:\\/]/g, "-");
-}
-
-/** Get the session directory for a project */
-export function getProjectSessionDir(projectPath: string): string {
-  const slug = projectPathToSlug(projectPath);
-  return path.join(getClaudeDir(), "projects", slug);
+/** Discovered session from history.jsonl */
+export interface DiscoveredSession {
+  readonly sessionId: string;
+  readonly firstPrompt: string;
+  readonly lastSeen: number; // Unix ms timestamp
 }
 
 /**
- * List session IDs for a project by scanning JSONL files.
- * Returns session IDs sorted by file modification time (newest first).
+ * Discover sessions for a project by reading history.jsonl.
+ * Returns unique sessions sorted by last seen (newest first).
  */
-export function listSessionIds(projectPath: string): readonly string[] {
-  const dir = getProjectSessionDir(projectPath);
-  if (!fs.existsSync(dir)) {
-    return [];
+export function discoverSessions(
+  workspacePath: string,
+): readonly DiscoveredSession[] {
+  const entries = readHistoryEntries();
+  const normalizedWorkspace = normalizePath(workspacePath);
+
+  // Group by sessionId, keep latest timestamp and first prompt per session
+  const sessionMap = new Map<
+    string,
+    { firstPrompt: string; lastSeen: number }
+  >();
+
+  for (const entry of entries) {
+    if (normalizePath(entry.project) !== normalizedWorkspace) continue;
+
+    const existing = sessionMap.get(entry.sessionId);
+    if (existing) {
+      // Update lastSeen to the most recent entry
+      if (entry.timestamp > existing.lastSeen) {
+        sessionMap.set(entry.sessionId, {
+          ...existing,
+          lastSeen: entry.timestamp,
+        });
+      }
+    } else {
+      sessionMap.set(entry.sessionId, {
+        firstPrompt: entry.display,
+        lastSeen: entry.timestamp,
+      });
+    }
   }
 
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  const jsonlFiles = entries
-    .filter((e) => e.isFile() && e.name.endsWith(".jsonl"))
-    .map((e) => ({
-      name: e.name,
-      mtime: fs.statSync(path.join(dir, e.name)).mtimeMs,
-    }))
-    .sort((a, b) => b.mtime - a.mtime);
+  const sessions: DiscoveredSession[] = [];
+  for (const [sessionId, data] of sessionMap) {
+    sessions.push({ sessionId, ...data });
+  }
 
-  return jsonlFiles.map((f) => f.name.replace(".jsonl", ""));
+  return sessions.sort((a, b) => b.lastSeen - a.lastSeen);
 }
 
 /**
- * Read the last entry from history.jsonl for a given session ID.
- * Returns the display text (first user prompt) if found.
+ * Read and parse all entries from history.jsonl.
+ * Returns entries in file order (oldest first).
  */
-export function getSessionDisplayName(sessionId: string): string | undefined {
+export function readHistoryEntries(): readonly HistoryEntry[] {
   const historyPath = path.join(getClaudeDir(), "history.jsonl");
   if (!fs.existsSync(historyPath)) {
-    return undefined;
+    return [];
   }
 
   const content = fs.readFileSync(historyPath, "utf-8");
   const lines = content.trim().split("\n");
+  const entries: HistoryEntry[] = [];
 
-  // Search from end (most recent first)
-  for (let i = lines.length - 1; i >= 0; i--) {
+  for (const line of lines) {
+    if (!line) continue;
     try {
-      const entry = JSON.parse(lines[i]) as HistoryEntry;
-      if (entry.sessionId === sessionId) {
-        return entry.display;
-      }
+      entries.push(JSON.parse(line) as HistoryEntry);
     } catch {
       // skip malformed lines
     }
   }
-  return undefined;
-}
 
-/**
- * Watch a project session directory for new JSONL files.
- * Calls `onNewSession` when a new session file appears.
- * Returns a cleanup function.
- */
-export function watchProjectDir(
-  projectPath: string,
-  knownIds: ReadonlySet<string>,
-  onNewSession: (sessionId: string) => void,
-): () => void {
-  const dir = getProjectSessionDir(projectPath);
-
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
-  const seen = new Set(knownIds);
-  let pollTimer: ReturnType<typeof setInterval> | undefined;
-
-  const check = (): void => {
-    const current = listSessionIds(projectPath);
-    for (const id of current) {
-      if (!seen.has(id)) {
-        seen.add(id);
-        onNewSession(id);
-      }
-    }
-  };
-
-  // Try fs.watch first, fall back to polling
-  try {
-    const watcher = fs.watch(dir, { persistent: false }, (_event, filename) => {
-      if (filename && filename.endsWith(".jsonl")) {
-        const id = filename.replace(".jsonl", "");
-        if (!seen.has(id)) {
-          seen.add(id);
-          onNewSession(id);
-        }
-      }
-    });
-
-    return () => {
-      watcher.close();
-    };
-  } catch {
-    // Fallback: poll every 2 seconds
-    pollTimer = setInterval(check, 2000);
-    return () => {
-      if (pollTimer) {
-        clearInterval(pollTimer);
-      }
-    };
-  }
+  return entries;
 }

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -33,7 +33,9 @@ const vscode = {
     }),
   },
   workspace: {
-    workspaceFolders: [{ uri: { fsPath: "C:\\dev\\test-project" } }],
+    workspaceFolders: [{ uri: { fsPath: "C:\\dev\\test-project" } }] as
+      | { uri: { fsPath: string } }[]
+      | undefined,
     getConfiguration: vi.fn(() => ({
       get: vi.fn((_key: string, defaultValue: unknown) => defaultValue),
     })),
@@ -41,15 +43,14 @@ const vscode = {
   },
   StatusBarAlignment: { Right: 2 },
   QuickPickItemKind: { Separator: -1 },
+  TerminalExitReason: { Process: 0, User: 1 },
 };
 
 vi.mock("vscode", () => vscode);
 
 // Mock claude-dir to avoid filesystem access
 vi.mock("./claude-dir", () => ({
-  listSessionIds: vi.fn(() => []),
-  getSessionDisplayName: vi.fn(() => undefined),
-  watchProjectDir: vi.fn(() => () => {}),
+  discoverSessions: vi.fn(() => []),
 }));
 
 describe("activate", () => {
@@ -75,12 +76,12 @@ describe("activate", () => {
 
     expect(vscode.window.createStatusBarItem).toHaveBeenCalledWith(2, 100);
     expect(mockStatusBarItem.command).toBe("claudeResurrect.showMenu");
-    expect(mockStatusBarItem.text).toBe("$(terminal) Claude: 0 sessions");
+    expect(mockStatusBarItem.text).toBe("$(terminal) Claude: 0 live · 0 idle");
     expect(mockStatusBarItem.show).toHaveBeenCalled();
     expect(mockStatusBarItem.hide).not.toHaveBeenCalled();
   });
 
-  it("registers all three commands", async () => {
+  it("registers showMenu and newSession commands", async () => {
     const { activate } = await import("./extension");
 
     const context = {
@@ -95,19 +96,16 @@ describe("activate", () => {
 
     expect(registeredCommands.has("claudeResurrect.showMenu")).toBe(true);
     expect(registeredCommands.has("claudeResurrect.newSession")).toBe(true);
-    expect(registeredCommands.has("claudeResurrect.resumeAll")).toBe(true);
   });
 
   it("hides status bar when no workspace folder", async () => {
-    vscode.workspace.workspaceFolders = undefined as never;
+    vscode.workspace.workspaceFolders = undefined;
 
     // Re-import to pick up the new workspace state
     vi.resetModules();
     vi.mock("vscode", () => vscode);
     vi.mock("./claude-dir", () => ({
-      listSessionIds: vi.fn(() => []),
-      getSessionDisplayName: vi.fn(() => undefined),
-      watchProjectDir: vi.fn(() => () => {}),
+      discoverSessions: vi.fn(() => []),
     }));
     const { activate } = await import("./extension");
 
@@ -126,14 +124,12 @@ describe("activate", () => {
   });
 
   it("listens for workspace folder changes when no folder at startup", async () => {
-    vscode.workspace.workspaceFolders = undefined as never;
+    vscode.workspace.workspaceFolders = undefined;
 
     vi.resetModules();
     vi.mock("vscode", () => vscode);
     vi.mock("./claude-dir", () => ({
-      listSessionIds: vi.fn(() => []),
-      getSessionDisplayName: vi.fn(() => undefined),
-      watchProjectDir: vi.fn(() => () => {}),
+      discoverSessions: vi.fn(() => []),
     }));
     const { activate } = await import("./extension");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,9 @@
 import * as vscode from "vscode";
+import * as crypto from "node:crypto";
 import { SessionStore } from "./session-store";
-import {
-  listSessionIds,
-  getSessionDisplayName,
-  watchProjectDir,
-} from "./claude-dir";
+import { discoverSessions } from "./claude-dir";
 import type { SessionMapping } from "./types";
-
-let cleanupWatcher: (() => void) | undefined;
+import type { DiscoveredSession } from "./claude-dir";
 
 export function activate(context: vscode.ExtensionContext): void {
   const store = SessionStore.fromState(context.globalState);
@@ -26,8 +22,16 @@ export function activate(context: vscode.ExtensionContext): void {
       statusBar.hide();
       return;
     }
-    const count = store.getByProject(projectPath).length;
-    statusBar.text = `$(terminal) Claude: ${count} session${count !== 1 ? "s" : ""}`;
+    const tracked = store.getByProject(projectPath);
+    const discovered = discoverSessions(projectPath);
+    // Deduplicate: discovered sessions that are already tracked
+    const trackedIds = new Set(tracked.map((m) => m.sessionId));
+    const untracked = discovered.filter((d) => !trackedIds.has(d.sessionId));
+    const live = tracked.filter((m) => m.status === "active").length;
+    const idle = tracked.filter((m) => m.status !== "active" && m.status !== "completed").length
+      + untracked.length;
+
+    statusBar.text = `$(terminal) Claude: ${live} live · ${idle} idle`;
     statusBar.tooltip = "Claude Resurrect — Click to manage sessions";
     statusBar.show();
   };
@@ -55,64 +59,39 @@ export function activate(context: vscode.ExtensionContext): void {
       }
       await startNewSession(store, projectPath, updateStatusBar);
     }),
-
-    vscode.commands.registerCommand("claudeResurrect.resumeAll", async () => {
-      if (!projectPath) {
-        vscode.window.showWarningMessage(
-          "Claude Resurrect: No workspace folder open.",
-        );
-        return;
-      }
-      await resumeAllSessions(store, projectPath, updateStatusBar);
-    }),
   );
 
   // --- Terminal lifecycle tracking ---
   context.subscriptions.push(
     vscode.window.onDidCloseTerminal((terminal) => {
-      if (projectPath) {
-        void store.remove(terminal.name, projectPath);
-        updateStatusBar();
+      if (!projectPath) return;
+
+      const reason = terminal.exitStatus?.reason;
+      if (reason === vscode.TerminalExitReason.Process) {
+        // CLI exited on its own (user typed exit, /exit, etc.) → completed
+        void store.markCompleted(terminal.name, projectPath);
+      } else {
+        // User closed terminal, VSCode shutdown, or unknown → restorable
+        // Note: Extension-disposed terminals also land here (intentional)
+        void store.markInactive(terminal.name, projectPath);
       }
+      updateStatusBar();
     }),
   );
 
   // --- Initialize project-specific features ---
   const initProject = (path: string): void => {
-    const knownIds = new Set(listSessionIds(path));
-
-    cleanupWatcher = watchProjectDir(path, knownIds, (sessionId) => {
-      const pending = pendingTerminals.shift();
-      if (pending) {
-        const displayName = getSessionDisplayName(sessionId);
-        const mapping: SessionMapping = {
-          terminalName: pending.name,
-          sessionId,
-          projectPath: path,
-          lastSeen: Date.now(),
-          firstPrompt: displayName,
-        };
-        void store.upsert(mapping);
-        updateStatusBar();
-      }
-    });
-
-    context.subscriptions.push({ dispose: () => cleanupWatcher?.() });
-
-    // Auto-restore
     const config = vscode.workspace.getConfiguration("claudeResurrect");
     const autoRestore = config.get<boolean>("autoRestore", true);
-    const ttlHours = config.get<number>("autoRestoreMaxAge", 24);
 
     if (autoRestore) {
-      void autoRestoreSessions(store, path, ttlHours, updateStatusBar);
+      void autoRestoreSessions(store, path, updateStatusBar);
     }
   };
 
   if (projectPath) {
     initProject(projectPath);
   } else {
-    // Workspace not ready yet — wait for folder to open
     const folderListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
       const newPath = getProjectPath();
       if (newPath) {
@@ -127,11 +106,8 @@ export function activate(context: vscode.ExtensionContext): void {
 }
 
 export function deactivate(): void {
-  cleanupWatcher?.();
+  // No cleanup needed — state is persisted immediately via globalState
 }
-
-// --- Pending terminal queue for session detection ---
-const pendingTerminals: vscode.Terminal[] = [];
 
 // --- Helper functions ---
 
@@ -154,78 +130,74 @@ async function startNewSession(
   projectPath: string,
   onUpdate: () => void,
 ): Promise<void> {
-  const count = store.getByProject(projectPath).length;
-  const name = `Claude #${count + 1}`;
+  const sessionId = crypto.randomUUID();
+  const active = store.getActive(projectPath);
+  const name = `Claude #${active.length + 1}`;
+
+  // Save to globalState BEFORE creating terminal (crash-safe)
+  await store.upsert({
+    terminalName: name,
+    sessionId,
+    projectPath,
+    lastSeen: Date.now(),
+    status: "active",
+  });
 
   const terminal = vscode.window.createTerminal({
     name,
     cwd: projectPath,
   });
   terminal.show();
-  terminal.sendText(getClaudePath());
+  terminal.sendText(`${getClaudePath()} --session-id ${sessionId}`);
 
-  // Queue for session detection
-  pendingTerminals.push(terminal);
   onUpdate();
 }
 
 async function resumeSession(
-  mapping: SessionMapping,
-): Promise<vscode.Terminal> {
-  const terminal = vscode.window.createTerminal({
-    name: mapping.terminalName,
-    cwd: mapping.projectPath,
-  });
-  terminal.sendText(`${getClaudePath()} --resume ${mapping.sessionId}`);
-  return terminal;
-}
-
-async function resumeAllSessions(
   store: SessionStore,
+  sessionId: string,
+  displayName: string,
   projectPath: string,
   onUpdate: () => void,
 ): Promise<void> {
-  const mappings = store.getByProject(projectPath);
-  if (mappings.length === 0) {
-    vscode.window.showInformationMessage(
-      "Claude Resurrect: No saved sessions to restore.",
-    );
-    return;
-  }
+  const terminalName = `Claude: ${displayName.slice(0, 30)}`;
 
-  for (const mapping of mappings) {
-    await resumeSession(mapping);
-  }
+  await store.upsert({
+    terminalName,
+    sessionId,
+    projectPath,
+    lastSeen: Date.now(),
+    firstPrompt: displayName,
+    status: "active",
+  });
+
+  const terminal = vscode.window.createTerminal({
+    name: terminalName,
+    cwd: projectPath,
+  });
+  terminal.sendText(`${getClaudePath()} --resume ${sessionId}`);
+  terminal.show();
+
   onUpdate();
-  vscode.window.showInformationMessage(
-    `Claude Resurrect: Restored ${mappings.length} session(s).`,
-  );
 }
 
+/** Auto-restore sessions that were active when VSCode died */
 async function autoRestoreSessions(
   store: SessionStore,
   projectPath: string,
-  ttlHours: number,
   onUpdate: () => void,
 ): Promise<void> {
-  const restorable = store.getRestorable(projectPath, ttlHours);
-  const expired = store.getExpired(projectPath, ttlHours);
+  const active = store.getActive(projectPath);
+  if (active.length === 0) return;
 
-  if (restorable.length === 0) {
-    return;
+  for (const mapping of active) {
+    const displayName = mapping.firstPrompt ?? mapping.sessionId.slice(0, 8);
+    await resumeSession(store, mapping.sessionId, displayName, projectPath, onUpdate);
   }
 
-  for (const mapping of restorable) {
-    await resumeSession(mapping);
-  }
-  onUpdate();
-
-  if (expired.length > 0) {
-    await store.pruneExpired(ttlHours);
-    vscode.window.showInformationMessage(
-      `Claude Resurrect: Restored ${restorable.length} session(s). ${expired.length} expired session(s) skipped.`,
-    );
-  }
+  vscode.window.showInformationMessage(
+    `Claude Resurrect: Restored ${active.length} interrupted session(s).`,
+  );
 }
 
 async function showQuickPick(
@@ -233,65 +205,140 @@ async function showQuickPick(
   projectPath: string,
   onUpdate: () => void,
 ): Promise<void> {
-  const mappings = store.getByProject(projectPath);
+  const config = vscode.workspace.getConfiguration("claudeResurrect");
+  const ttlHours = config.get<number>("autoRestoreMaxAge", 24);
+
+  const activeItems = store.getActive(projectPath);
+  const inactiveItems = store.getRestorable(projectPath, ttlHours);
+  const completedItems = store.getCompleted(projectPath, ttlHours);
+
+  // Discover sessions from history.jsonl that we don't track
+  const discovered = discoverSessions(projectPath);
+  const trackedIds = new Set(store.getByProject(projectPath).map((m) => m.sessionId));
+  const untrackedSessions = discovered.filter((d) => !trackedIds.has(d.sessionId));
 
   interface MenuItem extends vscode.QuickPickItem {
-    action: "new" | "resumeAll" | "session";
+    action: "new" | "continue" | "resume-tracked" | "resume-discovered";
     mapping?: SessionMapping;
+    discovered?: DiscoveredSession;
   }
 
-  const items: MenuItem[] = [
-    {
-      label: "$(add) New Session",
-      description: "Start a new Claude CLI session",
-      action: "new",
-    },
-    {
-      label: "$(debug-restart) Resume All",
-      description: `Restore all ${mappings.length} saved session(s)`,
-      action: "resumeAll",
-    },
-  ];
+  const items: MenuItem[] = [];
 
-  if (mappings.length > 0) {
+  // Active section
+  if (activeItems.length > 0) {
     items.push({
-      label: "",
+      label: "Active",
       kind: vscode.QuickPickItemKind.Separator,
-      action: "new", // unused
+      action: "new",
     });
-
-    for (const mapping of mappings) {
-      const age = formatAge(mapping.lastSeen);
+    for (const mapping of activeItems) {
       items.push({
-        label: `$(terminal) ${mapping.terminalName}`,
+        label: `$(circle-filled) ${mapping.terminalName}`,
         description: mapping.firstPrompt
-          ? `"${mapping.firstPrompt.slice(0, 40)}" — ${age}`
-          : `${mapping.sessionId.slice(0, 8)}... — ${age}`,
-        action: "session",
+          ? `"${mapping.firstPrompt.slice(0, 40)}" — ${formatAge(mapping.lastSeen)}`
+          : `${mapping.sessionId.slice(0, 8)}... — ${formatAge(mapping.lastSeen)}`,
+        action: "resume-tracked",
         mapping,
       });
     }
   }
 
+  // Resumable section (inactive tracked + untracked from history.jsonl)
+  const hasResumable = inactiveItems.length > 0 || untrackedSessions.length > 0;
+  if (hasResumable) {
+    items.push({
+      label: "Resumable",
+      kind: vscode.QuickPickItemKind.Separator,
+      action: "new",
+    });
+    for (const mapping of inactiveItems) {
+      items.push({
+        label: `$(circle-outline) ${mapping.firstPrompt ?? mapping.sessionId.slice(0, 8)}`,
+        description: formatAge(mapping.lastSeen),
+        action: "resume-tracked",
+        mapping,
+      });
+    }
+    for (const session of untrackedSessions) {
+      items.push({
+        label: `$(circle-outline) ${session.firstPrompt.slice(0, 40)}`,
+        description: formatAge(session.lastSeen),
+        action: "resume-discovered",
+        discovered: session,
+      });
+    }
+  }
+
+  // Completed section
+  if (completedItems.length > 0) {
+    items.push({
+      label: "Completed",
+      kind: vscode.QuickPickItemKind.Separator,
+      action: "new",
+    });
+    for (const mapping of completedItems) {
+      items.push({
+        label: `$(check) ${mapping.firstPrompt ?? mapping.sessionId.slice(0, 8)}`,
+        description: formatAge(mapping.lastSeen),
+        action: "resume-tracked",
+        mapping,
+      });
+    }
+  }
+
+  // Actions section
+  items.push({
+    label: "Actions",
+    kind: vscode.QuickPickItemKind.Separator,
+    action: "new",
+  });
+  items.push({
+    label: "$(add) New Session",
+    description: "Start a new Claude CLI session",
+    action: "new",
+  });
+  items.push({
+    label: "$(debug-continue) Continue Last",
+    description: "Resume the most recent session (claude --continue)",
+    action: "continue",
+  });
+
   const selected = await vscode.window.showQuickPick(items, {
     placeHolder: "Claude Resurrect",
   });
 
-  if (!selected) {
-    return;
-  }
+  if (!selected) return;
 
   switch (selected.action) {
     case "new":
       await startNewSession(store, projectPath, onUpdate);
       break;
-    case "resumeAll":
-      await resumeAllSessions(store, projectPath, onUpdate);
+    case "continue": {
+      const terminal = vscode.window.createTerminal({
+        name: "Claude: continue",
+        cwd: projectPath,
+      });
+      terminal.sendText(`${getClaudePath()} --continue`);
+      terminal.show();
       break;
-    case "session":
+    }
+    case "resume-tracked":
       if (selected.mapping) {
-        const terminal = await resumeSession(selected.mapping);
-        terminal.show();
+        const m = selected.mapping;
+        await resumeSession(
+          store,
+          m.sessionId,
+          m.firstPrompt ?? m.sessionId.slice(0, 8),
+          projectPath,
+          onUpdate,
+        );
+      }
+      break;
+    case "resume-discovered":
+      if (selected.discovered) {
+        const d = selected.discovered;
+        await resumeSession(store, d.sessionId, d.firstPrompt, projectPath, onUpdate);
       }
       break;
   }

--- a/src/normalize-path.ts
+++ b/src/normalize-path.ts
@@ -1,0 +1,4 @@
+/** Normalize path for cross-platform, case-insensitive comparison */
+export function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/").toLowerCase();
+}

--- a/src/session-store.test.ts
+++ b/src/session-store.test.ts
@@ -8,6 +8,7 @@ function createMapping(overrides: Partial<SessionMapping> = {}): SessionMapping 
     sessionId: "aaaa-bbbb-cccc-dddd",
     projectPath: "C:\\dev\\my-project",
     lastSeen: Date.now(),
+    status: "active",
     ...overrides,
   };
 }
@@ -68,46 +69,116 @@ describe("SessionStore", () => {
     expect(results).toHaveLength(2);
   });
 
-  it("getRestorable filters by TTL", () => {
+  it("getActive returns only active sessions", () => {
+    const { store } = createStore([
+      createMapping({ terminalName: "A", status: "active" }),
+      createMapping({ terminalName: "B", status: "inactive" }),
+      createMapping({ terminalName: "C", status: "completed" }),
+    ]);
+
+    const active = store.getActive("C:\\dev\\my-project");
+    expect(active).toHaveLength(1);
+    expect(active[0].terminalName).toBe("A");
+  });
+
+  it("getRestorable returns inactive within TTL", () => {
     const now = Date.now();
     const { store } = createStore([
       createMapping({
-        terminalName: "recent",
-        lastSeen: now - 1 * 60 * 60 * 1000, // 1 hour ago
+        terminalName: "recent-inactive",
+        status: "inactive",
+        lastSeen: now - 1 * 60 * 60 * 1000,
       }),
       createMapping({
-        terminalName: "old",
-        lastSeen: now - 48 * 60 * 60 * 1000, // 48 hours ago
+        terminalName: "old-inactive",
+        status: "inactive",
+        lastSeen: now - 48 * 60 * 60 * 1000,
+      }),
+      createMapping({
+        terminalName: "recent-active",
+        status: "active",
+        lastSeen: now - 1 * 60 * 60 * 1000,
+      }),
+      createMapping({
+        terminalName: "recent-completed",
+        status: "completed",
+        lastSeen: now - 1 * 60 * 60 * 1000,
       }),
     ]);
 
     const restorable = store.getRestorable("C:\\dev\\my-project", 24);
     expect(restorable).toHaveLength(1);
-    expect(restorable[0].terminalName).toBe("recent");
+    expect(restorable[0].terminalName).toBe("recent-inactive");
   });
 
-  it("getExpired returns only expired mappings", () => {
+  it("getCompleted returns completed within TTL", () => {
     const now = Date.now();
     const { store } = createStore([
       createMapping({
-        terminalName: "recent",
+        terminalName: "recent-completed",
+        status: "completed",
         lastSeen: now - 1 * 60 * 60 * 1000,
       }),
       createMapping({
-        terminalName: "old",
+        terminalName: "old-completed",
+        status: "completed",
         lastSeen: now - 48 * 60 * 60 * 1000,
+      }),
+      createMapping({
+        terminalName: "recent-active",
+        status: "active",
+        lastSeen: now - 1 * 60 * 60 * 1000,
       }),
     ]);
 
-    const expired = store.getExpired("C:\\dev\\my-project", 24);
-    expect(expired).toHaveLength(1);
-    expect(expired[0].terminalName).toBe("old");
+    const completed = store.getCompleted("C:\\dev\\my-project", 24);
+    expect(completed).toHaveLength(1);
+    expect(completed[0].terminalName).toBe("recent-completed");
   });
 
-  it("removes a mapping", async () => {
-    const { store } = createStore([createMapping()]);
-    await store.remove("Claude #1", "C:\\dev\\my-project");
-    expect(store.getAll()).toHaveLength(0);
+  it("markInactive transitions active to inactive", async () => {
+    const { store } = createStore([
+      createMapping({ status: "active" }),
+    ]);
+
+    await store.markInactive("Claude #1", "C:\\dev\\my-project");
+    expect(store.getAll()[0].status).toBe("inactive");
+  });
+
+  it("markInactive does not regress completed to inactive", async () => {
+    const { store } = createStore([
+      createMapping({ status: "completed" }),
+    ]);
+
+    await store.markInactive("Claude #1", "C:\\dev\\my-project");
+    expect(store.getAll()[0].status).toBe("completed");
+  });
+
+  it("markCompleted transitions active to completed", async () => {
+    const { store } = createStore([
+      createMapping({ status: "active" }),
+    ]);
+
+    await store.markCompleted("Claude #1", "C:\\dev\\my-project");
+    expect(store.getAll()[0].status).toBe("completed");
+  });
+
+  it("markInactive is no-op when mapping not found", async () => {
+    const { store, persisted } = createStore([createMapping()]);
+    await store.markInactive("nonexistent", "C:\\dev\\my-project");
+    expect(persisted.size).toBe(0); // no persist call
+  });
+
+  it("migrates legacy entries without status field", () => {
+    const legacy = {
+      terminalName: "Claude #1",
+      sessionId: "aaa",
+      projectPath: "C:\\dev\\foo",
+      lastSeen: Date.now(),
+    } as SessionMapping; // missing status
+
+    const { store } = createStore([legacy]);
+    expect(store.getAll()[0].status).toBe("inactive");
   });
 
   it("pruneExpired removes old entries and returns count", async () => {

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,4 +1,5 @@
 import type { SessionMapping } from "./types";
+import { normalizePath } from "./normalize-path";
 
 const STORAGE_KEY = "claudeResurrectMappings";
 
@@ -14,7 +15,11 @@ export class SessionStore {
     initial: SessionMapping[],
     persist: (key: string, value: unknown) => Thenable<void>,
   ) {
-    this.mappings = [...initial];
+    // Migrate legacy entries that lack a status field
+    this.mappings = initial.map((m) => ({
+      ...m,
+      status: m.status ?? "inactive",
+    }));
     this.persist = persist;
   }
 
@@ -39,16 +44,27 @@ export class SessionStore {
     );
   }
 
-  /** Get mappings within TTL (hours) for a project */
-  getRestorable(projectPath: string, ttlHours: number): readonly SessionMapping[] {
-    const cutoff = Date.now() - ttlHours * 60 * 60 * 1000;
-    return this.getByProject(projectPath).filter((m) => m.lastSeen >= cutoff);
+  /** Get active sessions (interrupted by VSCode restart) for auto-restore */
+  getActive(projectPath: string): readonly SessionMapping[] {
+    return this.getByProject(projectPath).filter(
+      (m) => m.status === "active",
+    );
   }
 
-  /** Get expired mappings (beyond TTL) for a project */
-  getExpired(projectPath: string, ttlHours: number): readonly SessionMapping[] {
+  /** Get inactive sessions within TTL for Quick Pick display */
+  getRestorable(projectPath: string, ttlHours: number): readonly SessionMapping[] {
     const cutoff = Date.now() - ttlHours * 60 * 60 * 1000;
-    return this.getByProject(projectPath).filter((m) => m.lastSeen < cutoff);
+    return this.getByProject(projectPath).filter(
+      (m) => m.status === "inactive" && m.lastSeen >= cutoff,
+    );
+  }
+
+  /** Get completed sessions within TTL for Quick Pick display */
+  getCompleted(projectPath: string, ttlHours: number): readonly SessionMapping[] {
+    const cutoff = Date.now() - ttlHours * 60 * 60 * 1000;
+    return this.getByProject(projectPath).filter(
+      (m) => m.status === "completed" && m.lastSeen >= cutoff,
+    );
   }
 
   /** Add or update a mapping */
@@ -69,14 +85,42 @@ export class SessionStore {
     await this.persist(STORAGE_KEY, this.mappings);
   }
 
-  /** Remove a mapping by terminal name and project */
-  async remove(terminalName: string, projectPath: string): Promise<void> {
+  /** Mark a session as inactive (terminal closed by user) */
+  async markInactive(terminalName: string, projectPath: string): Promise<void> {
     const normalized = normalizePath(projectPath);
-    this.mappings = this.mappings.filter(
-      (m) =>
-        !(m.terminalName === terminalName &&
-          normalizePath(m.projectPath) === normalized),
+    const idx = this.mappings.findIndex(
+      (m) => m.terminalName === terminalName &&
+        normalizePath(m.projectPath) === normalized,
     );
+    if (idx < 0) return;
+
+    const existing = this.mappings[idx];
+    // completed is a terminal state — don't regress to inactive
+    if (existing.status === "completed") return;
+
+    this.mappings = [
+      ...this.mappings.slice(0, idx),
+      { ...existing, status: "inactive", lastSeen: Date.now() },
+      ...this.mappings.slice(idx + 1),
+    ];
+    await this.persist(STORAGE_KEY, this.mappings);
+  }
+
+  /** Mark a session as completed (CLI exited normally) */
+  async markCompleted(terminalName: string, projectPath: string): Promise<void> {
+    const normalized = normalizePath(projectPath);
+    const idx = this.mappings.findIndex(
+      (m) => m.terminalName === terminalName &&
+        normalizePath(m.projectPath) === normalized,
+    );
+    if (idx < 0) return;
+
+    const existing = this.mappings[idx];
+    this.mappings = [
+      ...this.mappings.slice(0, idx),
+      { ...existing, status: "completed", lastSeen: Date.now() },
+      ...this.mappings.slice(idx + 1),
+    ];
     await this.persist(STORAGE_KEY, this.mappings);
   }
 
@@ -91,9 +135,4 @@ export class SessionStore {
     }
     return removed;
   }
-}
-
-/** Normalize path for cross-platform comparison */
-function normalizePath(p: string): string {
-  return p.replace(/\\/g, "/").toLowerCase();
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type SessionStatus = "active" | "inactive" | "completed";
+
 /** Terminal-to-session mapping persisted in globalState */
 export interface SessionMapping {
   readonly terminalName: string;
@@ -5,6 +7,7 @@ export interface SessionMapping {
   readonly projectPath: string;
   readonly lastSeen: number; // Unix ms timestamp
   readonly firstPrompt?: string; // first user input for display
+  readonly status: SessionStatus;
 }
 
 /** Entry from ~/.claude/history.jsonl */


### PR DESCRIPTION
## Summary

- Replace fs.watch + pendingTerminals FIFO with `claude --session-id <uuid>` for deterministic session tracking
- 3-state lifecycle: `active` → `inactive` (user closed terminal) / `completed` (CLI exited normally)
- Discover sessions from `~/.claude/history.jsonl` instead of slug-based directory scanning
- Status bar shows `live / idle` counts with real-time feedback
- Quick Pick UI with Active / Resumable / Completed / Actions sections
- Auto-restore only for sessions interrupted by VSCode crash (not user-closed)

## Changed files

| File | Change |
|------|--------|
| `src/types.ts` | Add `SessionStatus`, `HistoryEntry` types |
| `src/normalize-path.ts` | New shared path normalization utility |
| `src/claude-dir.ts` | Rewrite: `discoverSessions()` via history.jsonl |
| `src/session-store.ts` | 3-state lifecycle, `markInactive`/`markCompleted`, legacy migration |
| `src/extension.ts` | Full rewrite: `--session-id`, `TerminalExitReason`, new Quick Pick |
| `src/*.test.ts` | All tests updated (27 passing) |
| `package.json` | Remove `resumeAll` command |
| `docs/planning/` | Design document with critique reviews |

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run test` — 27 tests pass
- [x] `npm run compile` — build success
- [x] F5 manual test: status bar, Quick Pick, New Session, terminal close → inactive transition

Closes #5, #6, #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)