### PR TITLE
feat: show session file size in Quick Pick

### DIFF
--- a/src/claude-dir.ts
+++ b/src/claude-dir.ts
@@ -14,6 +14,7 @@ export interface DiscoveredSession {
   readonly sessionId: string;
   readonly firstPrompt: string;
   readonly lastSeen: number; // Unix ms timestamp
+  readonly fileSize: number; // bytes, 0 if file not found
 }
 
 /**
@@ -25,6 +26,7 @@ export function discoverSessions(
 ): readonly DiscoveredSession[] {
   const entries = readHistoryEntries();
   const normalizedWorkspace = normalizePath(workspacePath);
+  const projectDir = findProjectDir(workspacePath);
 
   // Group by sessionId, keep latest timestamp and first prompt per session
   const sessionMap = new Map<
@@ -54,10 +56,60 @@ export function discoverSessions(
 
   const sessions: DiscoveredSession[] = [];
   for (const [sessionId, data] of sessionMap) {
-    sessions.push({ sessionId, ...data });
+    const fileSize = projectDir ? getSessionFileSize(projectDir, sessionId) : 0;
+    sessions.push({ sessionId, ...data, fileSize });
   }
 
   return sessions.sort((a, b) => b.lastSeen - a.lastSeen);
+}
+
+/**
+ * Get session .jsonl file size in bytes.
+ * Returns 0 if file not found.
+ */
+function getSessionFileSize(projectDir: string, sessionId: string): number {
+  const filePath = path.join(projectDir, `${sessionId}.jsonl`);
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Find the project directory under ~/.claude/projects/ matching a workspace path.
+ * CLI slug: path.replace(/[^a-zA-Z0-9]/g, "-") — case-sensitive, so we try both.
+ */
+function findProjectDir(workspacePath: string): string | undefined {
+  const projectsDir = path.join(getClaudeDir(), "projects");
+  if (!fs.existsSync(projectsDir)) return undefined;
+  const slug = workspacePath.replace(/[^a-zA-Z0-9]/g, "-");
+  const candidate = path.join(projectsDir, slug);
+  if (fs.existsSync(candidate)) return candidate;
+  // Case mismatch fallback: scan dirs
+  try {
+    const normalizedSlug = slug.toLowerCase();
+    for (const dir of fs.readdirSync(projectsDir)) {
+      if (dir.toLowerCase() === normalizedSlug) {
+        return path.join(projectsDir, dir);
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+/**
+ * Look up the .jsonl file size for a session.
+ */
+export function lookupSessionFileSize(
+  workspacePath: string,
+  sessionId: string,
+): number {
+  const projectDir = findProjectDir(workspacePath);
+  if (!projectDir) return 0;
+  return getSessionFileSize(projectDir, sessionId);
 }
 
 /**

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -51,6 +51,7 @@ vi.mock("vscode", () => vscode);
 // Mock claude-dir to avoid filesystem access
 vi.mock("./claude-dir", () => ({
   discoverSessions: vi.fn(() => []),
+  lookupSessionFileSize: vi.fn(() => 0),
 }));
 
 describe("activate", () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as crypto from "node:crypto";
 import { SessionStore } from "./session-store";
-import { discoverSessions } from "./claude-dir";
+import { discoverSessions, lookupSessionFileSize } from "./claude-dir";
 import type { SessionMapping } from "./types";
 import type { DiscoveredSession } from "./claude-dir";
 
@@ -260,11 +260,14 @@ async function showQuickPick(
       action: "new",
     });
     for (const mapping of activeItems) {
+      const size = formatSize(lookupSessionFileSize(projectPath, mapping.sessionId));
       items.push({
         label: `$(circle-filled) ${mapping.terminalName}`,
-        description: mapping.firstPrompt
-          ? `"${mapping.firstPrompt.slice(0, 40)}" — ${formatAge(mapping.lastSeen)}`
-          : `${mapping.sessionId.slice(0, 8)}... — ${formatAge(mapping.lastSeen)}`,
+        description: [
+          mapping.firstPrompt ? `"${mapping.firstPrompt.slice(0, 40)}"` : mapping.sessionId.slice(0, 8),
+          size,
+          formatAge(mapping.lastSeen),
+        ].filter(Boolean).join(" · "),
         action: "resume-tracked",
         mapping,
       });
@@ -277,16 +280,18 @@ async function showQuickPick(
   for (const entry of merged) {
     if (remaining <= 0) break;
     if (entry.kind === "tracked") {
+      const size = formatSize(lookupSessionFileSize(projectPath, entry.mapping.sessionId));
       resumableMenuItems.push({
         label: `$(circle-outline) ${entry.mapping.firstPrompt ?? entry.mapping.sessionId.slice(0, 8)}`,
-        description: formatAge(entry.mapping.lastSeen),
+        description: [size, formatAge(entry.mapping.lastSeen)].filter(Boolean).join(" · "),
         action: "resume-tracked",
         mapping: entry.mapping,
       });
     } else {
+      const size = formatSize(entry.session.fileSize);
       resumableMenuItems.push({
         label: `$(circle-outline) ${entry.session.firstPrompt.slice(0, 40)}`,
-        description: formatAge(entry.session.lastSeen),
+        description: [size, formatAge(entry.session.lastSeen)].filter(Boolean).join(" · "),
         action: "resume-discovered",
         discovered: entry.session,
       });
@@ -307,9 +312,10 @@ async function showQuickPick(
   const completedMenuItems: MenuItem[] = [];
   for (const mapping of completedItems) {
     if (remaining <= 0) break;
+    const size = formatSize(lookupSessionFileSize(projectPath, mapping.sessionId));
     completedMenuItems.push({
       label: `$(check) ${mapping.firstPrompt ?? mapping.sessionId.slice(0, 8)}`,
-      description: formatAge(mapping.lastSeen),
+      description: [size, formatAge(mapping.lastSeen)].filter(Boolean).join(" · "),
       action: "resume-tracked",
       mapping,
     });
@@ -375,4 +381,13 @@ function formatAge(timestamp: number): string {
   }
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes === 0) return "";
+  if (bytes < 1024) return `${bytes}B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)}KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)}MB`;
 }


### PR DESCRIPTION
## Summary

- Display .jsonl file size (e.g. "373KB", "5.3MB") in Quick Pick descriptions
- Helps users identify sessions by conversation scale
- Format: `"firstPrompt · 373KB · 2h ago"`

## Changed files

| File | Change |
|------|--------|
| `src/claude-dir.ts` | Add `lookupSessionFileSize()`, `findProjectDir()`, `fileSize` field |
| `src/extension.ts` | Add `formatSize()`, show size in all Quick Pick sections |
| `src/extension.test.ts` | Add `lookupSessionFileSize` to claude-dir mock |

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run test` — 27 tests pass
- [x] `npm run compile` — build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)