### PR TITLE
chore: marketplace prep (.vscodeignore, CHANGELOG, categories)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,11 @@
+.vscode/
+.claude/
+src/
+docs/
+node_modules/
+*.vsix
+.gitignore
+tsconfig.json
+vitest.config.ts
+esbuild.mjs
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Status bar showing live / idle session counts per project
+- Quick Pick session manager: new session, continue last, resume past sessions
+- Auto-restore interrupted sessions on VSCode restart
+- Session discovery from `~/.claude/history.jsonl`
+- File size and first prompt display in session list
+- `isTransient` terminals — no ghost terminals after restart

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vscode": "^1.96.0"
   },
   "categories": [
-    "Other"
+    "AI"
   ],
   "activationEvents": [
     "onStartupFinished"


### PR DESCRIPTION
## Summary

- `.vscodeignore` 追加 — .vsix が 8.76MB → 18.9KB に縮小（node_modules, src/, docs/ 除外）
- `CHANGELOG.md` 追加 — v0.1.0 の機能一覧
- `package.json` categories を `"Other"` → `"AI"` に変更

Partially closes #10 (アイコンは別途)

## Test plan

- [ ] `npx @vscode/vsce package --no-dependencies` で .vsix が ~20KB 以内
- [ ] .vsix に `out/extension.js`, `package.json`, `readme.md`, `changelog.md`, `LICENSE` のみ含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)