### PR TITLE
docs: add README, LICENSE, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Claude Resurrect — Claude Code 設定
+
+## プロジェクト概要
+
+VSCode 再起動時に Claude Code CLI セッションを自動復元する拡張機能。
+
+## 開発コマンド
+
+```bash
+npm run typecheck  # 型チェック
+npm run test       # Vitest テスト
+npm run compile    # ビルド（esbuild で out/ に出力）
+npm run watch      # ファイル変更監視 + 自動ビルド
+npm run package    # .vsix パッケージ作成
+```
+
+**品質ゲート**（作業完了前に必ず実行）: `npm run typecheck && npm run test && npm run compile`
+
+## アーキテクチャ
+
+### ~/.claude/ アクセス制約
+
+- `claude-dir.ts` が唯一の `~/.claude/` アクセスモジュール
+- 他のモジュールから fs で直接 `~/.claude/` に触ることを禁止
+- 読み取り専用のみ。書き込み API は一切使用しない
+
+### テスト可能ファイル
+
+| ファイル | Vitest テスト可能 | 理由 |
+|---------|:-:|------|
+| claude-dir.ts | Yes | fs のみ依存。vscode API 非依存 |
+| session-store.ts | Yes | persist コールバックで DI 済み |
+| normalize-path.ts | Yes | 純粋関数 |
+| extension.ts | No | vscode API 依存。F5 デバッグで検証 |
+
+## コーディングスタイル
+
+- TypeScript strict
+- イミュータブル操作（spread で新オブジェクト作成）
+- `any` 禁止（`unknown` を使う）

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 orangewk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Terminal Session Recall
+
+> Unofficial VSCode extension — Automatically restore Claude Code CLI sessions after restart
+
+## Features
+
+- Status bar shows live and idle session counts for the current project
+- QuickPick session manager: start new sessions, resume interrupted or completed sessions
+- Automatically restores interrupted sessions when VSCode restarts
+
+## Requirements
+
+- Claude Code CLI must be installed and available on your PATH
+
+## Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| claudeResurrect.autoRestore | true | Automatically restore interrupted sessions on startup |
+| claudeResurrect.autoRestoreMaxAge | 24 | Maximum age (hours) of sessions to auto-restore |
+| claudeResurrect.claudePath | "claude" | Path to the Claude CLI executable |
+
+## Data Access
+
+This extension reads the following from `~/.claude/`:
+
+- **`history.jsonl`** — session history (session ID, project path, first prompt, timestamp)
+- **Directory listing** of `projects/<slug>/` (file names only, to locate session files)
+- **File size** of session JSONL files via `stat()` (content is not read)
+
+This extension does NOT:
+
+- Write to `~/.claude/` (read-only access)
+- Read authentication tokens or API keys
+- Parse full conversation history
+- Send any data over the network
+- Collect telemetry
+
+### How we enforce this
+
+- All `~/.claude/` access is isolated in a single read-only module (`claude-dir.ts`)
+- CI checks block PRs that introduce write APIs or network calls outside allowed modules
+- The extension is open source — you can audit the code
+
+## License
+
+MIT

--- a/docs/planning/2026-03-01-marketplace-release.md
+++ b/docs/planning/2026-03-01-marketplace-release.md
@@ -1,0 +1,50 @@
+# マーケットプレイス公開計画
+
+## 背景
+
+セッション管理の再設計（PR #8）が完了。F5 テストで基本動作は確認済み。
+マーケットプレイス公開前にドッグフーディング期間を設けて品質を担保する。
+
+## フェーズ
+
+### Phase 1: ローカルインストール + ドッグフーディング（〜1 週間）
+
+**目的**: 実使用で問題を洗い出す
+
+1. `npm run package` で `.vsix` を生成
+2. `code --install-extension claude-resurrect-0.1.0.vsix` でインストール
+3. 普段の開発で使い、以下を観察:
+   - セッションが正しく追跡されるか
+   - VSCode 再起動後に active セッションが自動復元されるか
+   - Quick Pick の表示が正しいか（live/idle カウント、セクション分類）
+   - history.jsonl が大量にあるときのパフォーマンス
+   - 複数ワークスペースでの動作
+4. 発見した問題は Issue に起票、修正してから次のフェーズへ
+
+### Phase 2: マーケットプレイス準備
+
+**目的**: 公開に必要なアセットを揃える
+
+| アセット | 状態 | 備考 |
+|---------|------|------|
+| README.md | 未作成 | 機能説明、スクリーンショット、インストール手順 |
+| CHANGELOG.md | 未作成 | v0.1.0 の変更内容 |
+| LICENSE | 未作成 | MIT（package.json に宣言済み） |
+| アイコン | 未作成 | 128x128 PNG、マーケットプレイス表示用 |
+| package.json `icon` フィールド | 未設定 | アイコンファイルへのパス |
+| package.json `categories` | `Other` | 必要に応じて見直し |
+| `.vscodeignore` | 未作成 | src/、docs/ 等を .vsix から除外 |
+
+### Phase 3: マーケットプレイス公開
+
+**目的**: 公開して利用可能にする
+
+1. Azure DevOps で Personal Access Token を取得
+2. `vsce login orangewk`
+3. `vsce publish --pre-release`（初回は pre-release 推奨）
+4. マーケットプレイスで表示確認
+5. GitHub リポの README にマーケットプレイスバッジを追加
+
+## 複雑度: 低
+
+コード変更はほぼなく、ドキュメント・アセット準備が中心。


### PR DESCRIPTION
## Summary

- `README.md` — 機能説明、設定、Data Access セクション
- `LICENSE` — MIT
- `CLAUDE.md` — 開発者向けプロジェクト設定（品質ゲート、アーキテクチャ制約）
- `docs/planning/2026-03-01-marketplace-release.md` — 3フェーズ公開計画

PR #19 で漏れていたファイル群。

🤖 Generated with [Claude Code](https://claude.com/claude-code)