### PR TITLE
feat: #39 support Claude Code custom-title for session display names

### DIFF
--- a/docs/planning/2026-03-05-custom-title-support.md
+++ b/docs/planning/2026-03-05-custom-title-support.md
@@ -1,0 +1,129 @@
+# 実装計画: セッション custom-title サポート (#39)
+
+## 要件の再確認
+
+Claude Code の `/rename` コマンドで付けたセッション名を TSR の QuickPick・ターミナルタブ名に反映する。
+
+- **データソース**: セッション JSONL 内の `{"type":"custom-title","customTitle":"..."}` エントリ
+- **表示優先度**: `customTitle` > `firstPrompt` > `sessionId.slice(0, 8)`
+- **対象箇所**: QuickPick メニュー（全セクション）、ターミナルタブ名、auto-restore 時のタブ名
+
+## 調査結果
+
+### custom-title エントリの構造
+
+```json
+{"type":"custom-title","customTitle":"session-quick-pick-ux","sessionId":"3d783908-..."}
+```
+
+- セッション JSONL のどこにでも出現しうる（行頭とは限らない）
+- 同一セッションに複数回出現可能（`/rename` を複数回実行した場合）→ **最後の出現を採用**
+- `readFirstPrompt()` と同じファイルを読むため、1 回の読み込みで両方取得可能
+
+### 現在の表示名の取得フロー
+
+| 箇所 | 現在の実装 | ファイル:行 |
+|------|-----------|------------|
+| QuickPick Active | `readFirstPrompt()` → `sessionId.slice(0, 8)` | `extension.ts:288-292` |
+| QuickPick Resumable (tracked) | `readFirstPrompt()` → `sessionId.slice(0, 8)` | `extension.ts:309-310` |
+| QuickPick Resumable (discovered) | `firstPrompt.slice(0, 40)` | `extension.ts:320` |
+| QuickPick Completed | `readFirstPrompt()` → `sessionId.slice(0, 8)` | `extension.ts:343-344` |
+| resume 時のタブ名 | `displayName` 引数（呼び出し元で決定） | `extension.ts:173` |
+| auto-restore 時のタブ名 | `readFirstPrompt()` → `sessionId.slice(0, 8)` | `extension.ts:209-210` |
+
+## 実装フェーズ
+
+### Phase 1: `readSessionDisplayName()` 関数の追加（claude-dir.ts）
+
+既存の `readFirstPrompt()` をリファクタして、1 回の JSONL 読み込みで `customTitle` と `firstPrompt` の両方を取得する新関数を作る。
+
+**新関数**:
+```typescript
+interface SessionDisplayInfo {
+  readonly customTitle: string | undefined;
+  readonly firstPrompt: string | undefined;
+}
+
+export function readSessionDisplayInfo(
+  workspacePath: string,
+  sessionId: string,
+): SessionDisplayInfo
+```
+
+- JSONL を 1 回走査し、`type: "custom-title"` の最後の `customTitle` と、`type: "user"` の最初のテキストを同時に収集
+- `readFirstPrompt()` は **そのまま残す**（後方互換性。非推奨にはしない — 呼び出し元が少ないため、次バージョンで自然消滅させる方がシンプル）
+
+**ヘルパー関数**:
+```typescript
+/** customTitle > firstPrompt > sessionId 短縮の優先度で表示名を返す */
+export function resolveDisplayName(
+  info: SessionDisplayInfo,
+  sessionId: string,
+): string
+```
+
+### Phase 2: extension.ts の表示名切り替え
+
+すべての `readFirstPrompt()` 呼び出しを `readSessionDisplayInfo()` + `resolveDisplayName()` に置き換え:
+
+1. **QuickPick Active セクション** (L288): description に `customTitle` or `firstPrompt`
+2. **QuickPick Resumable tracked** (L309-310): label に `customTitle` or `firstPrompt`
+3. **QuickPick Resumable discovered** (L320): label に `customTitle` or `firstPrompt`
+4. **QuickPick Completed** (L343-344): label に `customTitle` or `firstPrompt`
+5. **resume-tracked / resume-discovered** のアクション (L387-398): `resumeSession` の `displayName` 引数
+6. **autoRestoreSessions** (L209-210): タブ名
+
+### Phase 3: `DiscoveredSession` の拡張
+
+`discoverSessions()` が返す `DiscoveredSession` に `customTitle` を追加:
+
+```typescript
+export interface DiscoveredSession {
+  readonly sessionId: string;
+  readonly firstPrompt: string;
+  readonly customTitle: string | undefined;  // 追加
+  readonly lastSeen: number;
+  readonly fileSize: number;
+}
+```
+
+`discoverSessions()` 内で `readSessionDisplayInfo()` を呼んで `customTitle` を埋める。
+
+### Phase 4: テスト
+
+`claude-dir.test.ts` に以下を追加:
+
+1. `readSessionDisplayInfo` — custom-title エントリが 1 つの場合
+2. `readSessionDisplayInfo` — custom-title エントリが複数の場合（最後を採用）
+3. `readSessionDisplayInfo` — custom-title なし（firstPrompt のみ）
+4. `readSessionDisplayInfo` — 両方なし
+5. `resolveDisplayName` — 優先度テスト（customTitle > firstPrompt > fallback）
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/claude-dir.ts` | `readSessionDisplayInfo()`, `resolveDisplayName()` 追加。`DiscoveredSession` 拡張 |
+| `src/extension.ts` | 表示名取得を新 API に切り替え |
+| `src/claude-dir.test.ts` | 新関数のテスト追加 |
+
+## リスク
+
+| リスク | 影響 | 対策 |
+|-------|------|------|
+| JSONL ファイルが大きい場合の読み込みコスト | 既に `readFirstPrompt()` で全行読みしているため追加コストなし | 将来最適化（先頭 N バイト読み）は別 Issue |
+| `custom-title` の仕様が変わる | 表示名が取れなくなる（firstPrompt にフォールバック） | フォールバックチェーンで耐性あり |
+
+## 複雑度: 低
+
+- 変更ファイル 3 つ
+- 新しい外部依存なし
+- 既存の読み込みロジックの拡張のみ
+- フォールバックがあるため破壊リスクが低い
+
+## 経緯
+
+1. Issue #39 を当初「ユーザーが手動で名前をつける」機能として起票 → ユーザーが修正
+2. ユーザーから「Claude Code の `/rename` で付けた名前をそのまま使いたい」と要件明確化
+3. ユーザーがセッション JSONL 内の `type: "custom-title"` エントリの存在を教示
+4. 実データ確認: 同一セッションに `custom-title` が複数行ある場合がある → 最後を採用する設計に

--- a/src/claude-dir.test.ts
+++ b/src/claude-dir.test.ts
@@ -8,7 +8,7 @@ vi.mock("node:os", () => ({
   homedir: vi.fn(() => "/home/testuser"),
 }));
 
-import { discoverSessions, isValidSessionId, readHistoryEntries, getClaudeDir, readFirstPrompt } from "./claude-dir";
+import { discoverSessions, isValidSessionId, readHistoryEntries, getClaudeDir, readFirstPrompt, parseSessionDisplayInfo, resolveDisplayName } from "./claude-dir";
 
 /** Build a Stats-like mock for a regular file/directory (not a symlink) */
 function makeStatsMock(size = 0): fs.Stats {
@@ -382,5 +382,100 @@ describe("isValidSessionId", () => {
 
   it("rejects a plain alphanumeric string (no hyphens)", () => {
     expect(isValidSessionId("550e8400e29b41d4a716446655440000")).toBe(false);
+  });
+});
+
+describe("parseSessionDisplayInfo", () => {
+  it("extracts customTitle from a single custom-title entry", () => {
+    const content = [
+      JSON.stringify({ type: "user", message: { content: "hello" } }),
+      JSON.stringify({ type: "custom-title", customTitle: "my session", sessionId: UUID_A }),
+    ].join("\n");
+
+    const info = parseSessionDisplayInfo(content);
+    expect(info.customTitle).toBe("my session");
+    expect(info.firstPrompt).toBe("hello");
+  });
+
+  it("uses the last custom-title when multiple exist", () => {
+    const content = [
+      JSON.stringify({ type: "custom-title", customTitle: "first name", sessionId: UUID_A }),
+      JSON.stringify({ type: "user", message: { content: "hello" } }),
+      JSON.stringify({ type: "custom-title", customTitle: "renamed", sessionId: UUID_A }),
+    ].join("\n");
+
+    const info = parseSessionDisplayInfo(content);
+    expect(info.customTitle).toBe("renamed");
+  });
+
+  it("returns undefined customTitle when no custom-title entry exists", () => {
+    const content = [
+      JSON.stringify({ type: "user", message: { content: "hello" } }),
+      JSON.stringify({ type: "assistant", message: { content: "hi" } }),
+    ].join("\n");
+
+    const info = parseSessionDisplayInfo(content);
+    expect(info.customTitle).toBeUndefined();
+    expect(info.firstPrompt).toBe("hello");
+  });
+
+  it("returns both undefined when file has no relevant entries", () => {
+    const content = [
+      JSON.stringify({ type: "system", message: { content: "system msg" } }),
+    ].join("\n");
+
+    const info = parseSessionDisplayInfo(content);
+    expect(info.customTitle).toBeUndefined();
+    expect(info.firstPrompt).toBeUndefined();
+  });
+
+  it("handles empty content", () => {
+    const info = parseSessionDisplayInfo("");
+    expect(info.customTitle).toBeUndefined();
+    expect(info.firstPrompt).toBeUndefined();
+  });
+
+  it("ignores custom-title with non-string customTitle", () => {
+    const content = [
+      JSON.stringify({ type: "custom-title", customTitle: 123, sessionId: UUID_A }),
+      JSON.stringify({ type: "user", message: { content: "hello" } }),
+    ].join("\n");
+
+    const info = parseSessionDisplayInfo(content);
+    expect(info.customTitle).toBeUndefined();
+    expect(info.firstPrompt).toBe("hello");
+  });
+
+  it("skips malformed lines and continues", () => {
+    const content = [
+      "not json {{{",
+      JSON.stringify({ type: "custom-title", customTitle: "good title", sessionId: UUID_A }),
+    ].join("\n");
+
+    const info = parseSessionDisplayInfo(content);
+    expect(info.customTitle).toBe("good title");
+  });
+});
+
+describe("resolveDisplayName", () => {
+  it("prefers customTitle over firstPrompt", () => {
+    expect(resolveDisplayName(
+      { customTitle: "my title", firstPrompt: "hello world" },
+      UUID_A,
+    )).toBe("my title");
+  });
+
+  it("falls back to firstPrompt when no customTitle", () => {
+    expect(resolveDisplayName(
+      { customTitle: undefined, firstPrompt: "hello world" },
+      UUID_A,
+    )).toBe("hello world");
+  });
+
+  it("falls back to short sessionId when both are undefined", () => {
+    expect(resolveDisplayName(
+      { customTitle: undefined, firstPrompt: undefined },
+      UUID_A,
+    )).toBe("aaaaaaaa");
   });
 });

--- a/src/claude-dir.ts
+++ b/src/claude-dir.ts
@@ -17,10 +17,17 @@ export function isValidSessionId(id: string): boolean {
   return UUID_RE.test(id);
 }
 
+/** Display info extracted from a session JSONL file */
+export interface SessionDisplayInfo {
+  readonly customTitle: string | undefined;
+  readonly firstPrompt: string | undefined;
+}
+
 /** Discovered session from history.jsonl */
 export interface DiscoveredSession {
   readonly sessionId: string;
   readonly firstPrompt: string;
+  readonly customTitle: string | undefined;
   readonly lastSeen: number; // Unix ms timestamp
   readonly fileSize: number; // bytes, 0 if file not found
 }
@@ -66,7 +73,8 @@ export function discoverSessions(
   const sessions: DiscoveredSession[] = [];
   for (const [sessionId, data] of sessionMap) {
     const fileSize = projectDir ? getSessionFileSize(projectDir, sessionId) : 0;
-    sessions.push({ sessionId, ...data, fileSize });
+    const displayInfo = readSessionDisplayInfo(workspacePath, sessionId);
+    sessions.push({ sessionId, ...data, customTitle: displayInfo.customTitle, fileSize });
   }
 
   return sessions.sort((a, b) => b.lastSeen - a.lastSeen);
@@ -137,53 +145,88 @@ export function lookupSessionFileSize(
 }
 
 /**
+ * Read display info (customTitle + firstPrompt) from a session JSONL file.
+ * Scans the entire file once to find:
+ * - The last `type: "custom-title"` entry (most recent rename)
+ * - The first `type: "user"` message text
+ */
+export function readSessionDisplayInfo(
+  workspacePath: string,
+  sessionId: string,
+): SessionDisplayInfo {
+  const empty: SessionDisplayInfo = { customTitle: undefined, firstPrompt: undefined };
+  if (!isValidSessionId(sessionId)) return empty;
+  const projectDir = findProjectDir(workspacePath);
+  if (!projectDir) return empty;
+  const filePath = path.join(projectDir, `${sessionId}.jsonl`);
+  try {
+    const stat = fs.lstatSync(filePath);
+    if (stat.isSymbolicLink()) return empty;
+    const fd = fs.openSync(filePath, fs.constants.O_RDONLY);
+    try {
+      const content = fs.readFileSync(fd, "utf-8");
+      return parseSessionDisplayInfo(content);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return empty;
+  }
+}
+
+/** Parse JSONL content to extract customTitle and firstPrompt */
+export function parseSessionDisplayInfo(content: string): SessionDisplayInfo {
+  let customTitle: string | undefined;
+  let firstPrompt: string | undefined;
+
+  for (const line of content.split("\n")) {
+    if (!line) continue;
+    try {
+      const entry = JSON.parse(line) as {
+        type?: string;
+        customTitle?: string;
+        message?: { content?: unknown };
+      };
+      if (entry.type === "custom-title" && typeof entry.customTitle === "string") {
+        customTitle = entry.customTitle;
+      }
+      if (!firstPrompt && entry.type === "user" && entry.message?.content) {
+        const text =
+          typeof entry.message.content === "string"
+            ? entry.message.content
+            : Array.isArray(entry.message.content)
+              ? (entry.message.content as { type: string; text?: string }[]).find(
+                  (c) => c.type === "text",
+                )?.text ?? ""
+              : "";
+        const trimmed = text.slice(0, 80);
+        if (trimmed) firstPrompt = trimmed;
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+
+  return { customTitle, firstPrompt };
+}
+
+/** Resolve display name with priority: customTitle > firstPrompt > short sessionId */
+export function resolveDisplayName(
+  info: SessionDisplayInfo,
+  sessionId: string,
+): string {
+  return info.customTitle ?? info.firstPrompt ?? sessionId.slice(0, 8);
+}
+
+/**
  * Read the first user prompt from a session JSONL file.
- * Opens read-only, reads only until the first user entry is found.
- * Returns undefined on any failure (graceful fallback).
- *
- * Note: currently reads the full file content. Future optimization:
- * read only the first N bytes to avoid loading large JSONL files.
+ * @deprecated Use readSessionDisplayInfo() + resolveDisplayName() instead.
  */
 export function readFirstPrompt(
   workspacePath: string,
   sessionId: string,
 ): string | undefined {
-  if (!isValidSessionId(sessionId)) return undefined;
-  const projectDir = findProjectDir(workspacePath);
-  if (!projectDir) return undefined;
-  const filePath = path.join(projectDir, `${sessionId}.jsonl`);
-  try {
-    const stat = fs.lstatSync(filePath);
-    if (stat.isSymbolicLink()) return undefined;
-    const fd = fs.openSync(filePath, fs.constants.O_RDONLY);
-    try {
-      const content = fs.readFileSync(fd, "utf-8");
-      for (const line of content.split("\n")) {
-        if (!line) continue;
-        try {
-          const entry = JSON.parse(line) as { type?: string; message?: { content?: unknown } };
-          if (entry.type === "user" && entry.message?.content) {
-            const text =
-              typeof entry.message.content === "string"
-                ? entry.message.content
-                : Array.isArray(entry.message.content)
-                  ? (entry.message.content as { type: string; text?: string }[]).find(
-                      (c) => c.type === "text",
-                    )?.text ?? ""
-                  : "";
-            return text.slice(0, 80) || undefined;
-          }
-        } catch {
-          // skip malformed line
-        }
-      }
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
+  return readSessionDisplayInfo(workspacePath, sessionId).firstPrompt;
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as crypto from "node:crypto";
 import { SessionStore } from "./session-store";
-import { discoverSessions, isValidSessionId, lookupSessionFileSize, readFirstPrompt } from "./claude-dir";
+import { discoverSessions, isValidSessionId, lookupSessionFileSize, readSessionDisplayInfo, resolveDisplayName } from "./claude-dir";
 import type { SessionMapping } from "./types";
 import type { DiscoveredSession } from "./claude-dir";
 
@@ -206,8 +206,8 @@ async function autoRestoreSessions(
   const skipped = active.length - toRestore.length;
 
   for (const mapping of toRestore) {
-    const displayName =
-      readFirstPrompt(projectPath, mapping.sessionId) ?? mapping.sessionId.slice(0, 8);
+    const info = readSessionDisplayInfo(projectPath, mapping.sessionId);
+    const displayName = resolveDisplayName(info, mapping.sessionId);
     await resumeSession(store, mapping.sessionId, displayName, projectPath, onUpdate);
   }
 
@@ -285,11 +285,12 @@ async function showQuickPick(
     });
     for (const mapping of activeItems) {
       const size = formatSize(lookupSessionFileSize(projectPath, mapping.sessionId));
-      const activePrompt = readFirstPrompt(projectPath, mapping.sessionId);
+      const activeInfo = readSessionDisplayInfo(projectPath, mapping.sessionId);
+      const activeDisplay = activeInfo.customTitle ?? activeInfo.firstPrompt;
       items.push({
         label: `$(circle-filled) ${mapping.terminalName}`,
         description: [
-          activePrompt ? `"${activePrompt.slice(0, 40)}"` : mapping.sessionId.slice(0, 8),
+          activeDisplay ? `"${activeDisplay.slice(0, 40)}"` : mapping.sessionId.slice(0, 8),
           size,
           formatAge(mapping.lastSeen),
         ].filter(Boolean).join(" · "),
@@ -306,18 +307,19 @@ async function showQuickPick(
     if (remaining <= 0) break;
     if (entry.kind === "tracked") {
       const size = formatSize(lookupSessionFileSize(projectPath, entry.mapping.sessionId));
-      const trackedPrompt =
-        readFirstPrompt(projectPath, entry.mapping.sessionId) ?? entry.mapping.sessionId.slice(0, 8);
+      const trackedInfo = readSessionDisplayInfo(projectPath, entry.mapping.sessionId);
+      const trackedDisplay = resolveDisplayName(trackedInfo, entry.mapping.sessionId);
       resumableMenuItems.push({
-        label: `$(circle-outline) ${trackedPrompt}`,
+        label: `$(circle-outline) ${trackedDisplay}`,
         description: [size, formatAge(entry.mapping.lastSeen)].filter(Boolean).join(" · "),
         action: "resume-tracked",
         mapping: entry.mapping,
       });
     } else {
       const size = formatSize(entry.session.fileSize);
+      const discoveredDisplay = entry.session.customTitle ?? entry.session.firstPrompt.slice(0, 40);
       resumableMenuItems.push({
-        label: `$(circle-outline) ${entry.session.firstPrompt.slice(0, 40)}`,
+        label: `$(circle-outline) ${discoveredDisplay}`,
         description: [size, formatAge(entry.session.lastSeen)].filter(Boolean).join(" · "),
         action: "resume-discovered",
         discovered: entry.session,
@@ -340,10 +342,10 @@ async function showQuickPick(
   for (const mapping of completedItems) {
     if (remaining <= 0) break;
     const size = formatSize(lookupSessionFileSize(projectPath, mapping.sessionId));
-    const completedPrompt =
-      readFirstPrompt(projectPath, mapping.sessionId) ?? mapping.sessionId.slice(0, 8);
+    const completedInfo = readSessionDisplayInfo(projectPath, mapping.sessionId);
+    const completedDisplay = resolveDisplayName(completedInfo, mapping.sessionId);
     completedMenuItems.push({
-      label: `$(check) ${completedPrompt}`,
+      label: `$(check) ${completedDisplay}`,
       description: [size, formatAge(mapping.lastSeen)].filter(Boolean).join(" · "),
       action: "resume-tracked",
       mapping,
@@ -383,10 +385,11 @@ async function showQuickPick(
     case "resume-tracked":
       if (selected.mapping) {
         const m = selected.mapping;
+        const resumeInfo = readSessionDisplayInfo(projectPath, m.sessionId);
         await resumeSession(
           store,
           m.sessionId,
-          readFirstPrompt(projectPath, m.sessionId) ?? m.sessionId.slice(0, 8),
+          resolveDisplayName(resumeInfo, m.sessionId),
           projectPath,
           onUpdate,
         );
@@ -395,7 +398,8 @@ async function showQuickPick(
     case "resume-discovered":
       if (selected.discovered) {
         const d = selected.discovered;
-        await resumeSession(store, d.sessionId, d.firstPrompt, projectPath, onUpdate);
+        const displayName = d.customTitle ?? d.firstPrompt;
+        await resumeSession(store, d.sessionId, displayName, projectPath, onUpdate);
       }
       break;
   }


### PR DESCRIPTION
## Summary

- Read `custom-title` entries from Claude Code session JSONL (set by `/rename` command) and use them as display names in QuickPick, terminal tab names, and auto-restore
- Display priority: `customTitle` > `firstPrompt` > `sessionId` short hash
- New `readSessionDisplayInfo()` scans JSONL once for both customTitle and firstPrompt
- New `resolveDisplayName()` helper for consistent priority resolution

Closes #39

## Test plan

- [x] `parseSessionDisplayInfo` — single/multiple custom-title, no custom-title, malformed lines
- [x] `resolveDisplayName` — priority chain (customTitle > firstPrompt > fallback)
- [x] All 58 tests pass
- [ ] F5 debug: verify QuickPick shows custom title for sessions renamed via `/rename`

🤖 Generated with [Claude Code](https://claude.com/claude-code)