### PR TITLE
fix: QuickPick ghost duplicate after auto-restore

### DIFF
--- a/src/session-store.test.ts
+++ b/src/session-store.test.ts
@@ -41,15 +41,15 @@ describe("SessionStore", () => {
     expect(store.getAll()[0]).toEqual(mapping);
   });
 
-  it("updates existing mapping by terminalName + projectPath", async () => {
-    const original = createMapping({ sessionId: "old-id" });
+  it("updates existing mapping by sessionId + projectPath", async () => {
+    const original = createMapping({ terminalName: "TS Recall #1" });
     const { store } = createStore([original]);
 
-    const updated = createMapping({ sessionId: "new-id" });
+    const updated = createMapping({ terminalName: "TS Recall: new name" });
     await store.upsert(updated);
 
     expect(store.getAll()).toHaveLength(1);
-    expect(store.getAll()[0].sessionId).toBe("new-id");
+    expect(store.getAll()[0].terminalName).toBe("TS Recall: new name");
   });
 
   it("persists on upsert", async () => {

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -67,10 +67,10 @@ export class SessionStore {
     );
   }
 
-  /** Add or update a mapping */
+  /** Add or update a mapping (keyed by sessionId + projectPath) */
   async upsert(mapping: SessionMapping): Promise<void> {
     const idx = this.mappings.findIndex(
-      (m) => m.terminalName === mapping.terminalName &&
+      (m) => m.sessionId === mapping.sessionId &&
         normalizePath(m.projectPath) === normalizePath(mapping.projectPath),
     );
     if (idx >= 0) {


### PR DESCRIPTION
## Summary

- `upsert()` was keyed by `terminalName + projectPath`, but auto-restore changes the terminalName (from `TS Recall #1` to `TS Recall: <prompt>`), creating a ghost duplicate entry in globalState
- The old entry's terminal close handler marks it "inactive", causing the same session to appear in both Active and Resumable sections
- Fix: key `upsert()` by `sessionId + projectPath` instead — the session's true identity

## Test plan

- [x] Updated test to verify upsert by sessionId
- [x] All 58 tests pass
- [ ] F5 debug: start session → close VSCode → reopen → verify no duplicate in QuickPick

🤖 Generated with [Claude Code](https://claude.com/claude-code)