### PR TITLE
feat: prune dead processes on startup before auto-restore

### DIFF
--- a/docs/planning/2026-03-08-process-liveness-check.md
+++ b/docs/planning/2026-03-08-process-liveness-check.md
@@ -1,0 +1,169 @@
+# 復元時プロセス生存確認 (#48)
+
+## 要件の再確認
+
+- セッション復元時（`activate` → `autoRestoreSessions`）に、`"active"` な SessionMapping の OS プロセスが実際に生きているか確認する
+- 死んでいれば `"inactive"` に更新してから復元フローに進む
+- PID 再利用を誤検出しない（PID + 起動時刻で照合）
+- プロセス情報取得失敗時は安全側に倒す（`"active"` のまま維持）
+
+## 現状の復元フロー
+
+```
+activate()
+  → store.pruneExpired(336)       // 14日超を削除
+  → autoRestoreSessions()         // "active" を復元
+      → store.getActive(project)  // status === "active" を取得
+      → resumeSession() × N      // claude --resume で復元
+```
+
+**問題:** `getActive()` が返すセッションに、OS プロセスが既に死んでいるものが含まれる。
+
+## 設計
+
+### 方針
+
+`autoRestoreSessions()` の**前**に、`"active"` セッションの生存確認を挟む。
+
+```
+activate()
+  → store.pruneExpired(336)
+  → store.pruneDeadProcesses(project)  // ★ 追加
+  → autoRestoreSessions()
+```
+
+### SessionMapping の型拡張
+
+```typescript
+export interface SessionMapping {
+  readonly terminalName: string;
+  readonly sessionId: string;
+  readonly projectPath: string;
+  readonly lastSeen: number;
+  readonly status: SessionStatus;
+  readonly pid?: number;            // ★ 追加
+  readonly pidCreatedAt?: number;   // ★ 追加（Unix ms）
+}
+```
+
+`pid` と `pidCreatedAt` は `startNewSession()` / `resumeSession()` でターミナル作成後に記録する。
+
+### プロセス生存確認ロジック
+
+新ファイル: `src/process-check.ts`
+
+```typescript
+export interface ProcessInfo {
+  pid: number;
+  creationDate: number; // Unix ms
+}
+
+/**
+ * PID が生きていて、かつ起動時刻が一致するか確認する。
+ * 取得失敗時は undefined を返す（判定不能）。
+ */
+export async function isProcessAlive(
+  pid: number,
+  expectedCreatedAt: number,
+  toleranceMs?: number
+): Promise<boolean | undefined>
+```
+
+**Windows 実装:**
+
+```typescript
+// child_process.execFile で tasklist を使う
+// tasklist /FI "PID eq <pid>" /FO CSV /NH
+// → プロセス存在チェック
+//
+// 起動時刻の取得は wmic or PowerShell:
+// wmic process where "ProcessId=<pid>" get CreationDate
+// → 20260307091212.123456+540 形式 → parse して比較
+```
+
+**判定ロジック:**
+1. `pid` が `undefined` → 判定不能 → `undefined`（安全側: active のまま）
+2. プロセスが存在しない → `false`（死亡確定）
+3. プロセスが存在 + 起動時刻が `toleranceMs`（デフォルト 5000ms）以内で一致 → `true`
+4. プロセスが存在 + 起動時刻が不一致 → `false`（PID 再利用）
+5. 起動時刻の取得失敗 → `undefined`（安全側）
+
+### SessionStore への追加メソッド
+
+```typescript
+async pruneDeadProcesses(projectPath: string): Promise<number> {
+  const actives = this.getActive(projectPath);
+  let pruned = 0;
+  for (const m of actives) {
+    if (m.pid == null) continue;  // pid未記録 → スキップ（安全側）
+    const alive = await isProcessAlive(m.pid, m.pidCreatedAt ?? 0);
+    if (alive === false) {
+      await this.markInactive(m.terminalName, m.projectPath);
+      pruned++;
+    }
+    // alive === true or undefined → 何もしない
+  }
+  return pruned;
+}
+```
+
+### pid の記録タイミング
+
+`startNewSession()` と `resumeSession()` で、ターミナル作成後に `processId` を取得:
+
+```typescript
+const terminal = vscode.window.createTerminal({ name, cwd });
+// Terminal.processId は Thenable<number | undefined>
+const pid = await terminal.processId;
+if (pid != null) {
+  // pid + 現在時刻（近似値）で upsert
+  await store.upsert({ ...mapping, pid, pidCreatedAt: Date.now() });
+}
+```
+
+**注意:** `pidCreatedAt` は厳密にはプロセスの起動時刻ではなく「記録時刻」。`toleranceMs` で吸収する。
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/types.ts` | `pid?`, `pidCreatedAt?` 追加 |
+| `src/process-check.ts` | **新規** — プロセス生存確認 |
+| `src/session-store.ts` | `pruneDeadProcesses()` 追加 |
+| `src/extension.ts` | activate で呼び出し + pid 記録 |
+| `src/process-check.test.ts` | **新規** — 生存確認テスト |
+| `src/session-store.test.ts` | `pruneDeadProcesses` テスト追加 |
+| `src/extension.test.ts` | pid 記録の検証追加 |
+
+## 実装フェーズ
+
+### Phase 1: 型拡張 + process-check モジュール
+- `types.ts` に `pid?`, `pidCreatedAt?` 追加
+- `process-check.ts` 新規作成（`isProcessAlive()`）
+- `process-check.test.ts` でユニットテスト
+
+### Phase 2: SessionStore 拡張
+- `pruneDeadProcesses()` 追加
+- テスト追加（mock で `isProcessAlive` を注入）
+
+### Phase 3: extension.ts 統合
+- `activate()` で `pruneDeadProcesses()` 呼び出し
+- `startNewSession()` / `resumeSession()` で pid 記録
+- テスト更新
+
+### Phase 4: 動作確認
+- ビルド + 手動テスト（セッション起動 → プロセス kill → VS Code リロード → ゾンビが消えること）
+- 既存テスト全通過
+
+## リスク
+
+| リスク | 重大度 | 対策 |
+|-------|--------|------|
+| `wmic` が将来の Windows で非推奨化 | LOW | PowerShell にフォールバック可能。現時点では wmic で十分 |
+| `Terminal.processId` が shell の PID で、claude CLI の PID ではない | MEDIUM | shell が死ねば CLI も死ぬので、shell PID の生存確認で十分 |
+| 既存の pid 未記録セッション | LOW | `pid == null` はスキップ（安全側）。徐々に記録済みに移行 |
+| `pidCreatedAt` の精度 | LOW | toleranceMs = 5000ms で吸収。完全一致は求めない |
+
+## 複雑度: 低〜中
+
+新規ファイル1つ、既存変更3ファイル。ロジックはシンプルだが Windows プロセス情報取得の実装詳細に注意。

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,9 +81,13 @@ export function activate(context: vscode.ExtensionContext): void {
     // 14日（336時間）超過のマッピングを globalState から削除
     void store.pruneExpired(336);
 
-    if (autoRestore) {
-      void autoRestoreSessions(store, path, updateStatusBar);
-    }
+    // Prune sessions whose OS process has died, then auto-restore
+    void store.pruneDeadProcesses(path).then(() => {
+      updateStatusBar();
+      if (autoRestore) {
+        void autoRestoreSessions(store, path, updateStatusBar);
+      }
+    });
   };
 
   if (projectPath) {
@@ -132,13 +136,14 @@ async function startNewSession(
   const name = `TS Recall #${active.length + 1}`;
 
   // Save to globalState BEFORE creating terminal (crash-safe)
-  await store.upsert({
+  const mapping: SessionMapping = {
     terminalName: name,
     sessionId,
     projectPath,
     lastSeen: Date.now(),
     status: "active",
-  });
+  };
+  await store.upsert(mapping);
 
   const terminal = vscode.window.createTerminal({
     name,
@@ -147,6 +152,12 @@ async function startNewSession(
   });
   terminal.show();
   terminal.sendText(`${getClaudePath()} --session-id ${sessionId}`);
+
+  // Record PID for liveness checking on next startup
+  const pid = await terminal.processId;
+  if (pid != null) {
+    await store.upsert({ ...mapping, pid, pidCreatedAt: Date.now() });
+  }
 
   onUpdate();
 }
@@ -172,13 +183,14 @@ async function resumeSession(
 
   const terminalName = `TS Recall: ${displayName.slice(0, 30)}`;
 
-  await store.upsert({
+  const mapping: SessionMapping = {
     terminalName,
     sessionId,
     projectPath,
     lastSeen: Date.now(),
     status: "active",
-  });
+  };
+  await store.upsert(mapping);
 
   const terminal = vscode.window.createTerminal({
     name: terminalName,
@@ -187,6 +199,12 @@ async function resumeSession(
   });
   terminal.sendText(`${getClaudePath()} --resume ${sessionId}`);
   terminal.show();
+
+  // Record PID for liveness checking on next startup
+  const pid = await terminal.processId;
+  if (pid != null) {
+    await store.upsert({ ...mapping, pid, pidCreatedAt: Date.now() });
+  }
 
   onUpdate();
 }

--- a/src/process-check.test.ts
+++ b/src/process-check.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { parseWmicDate } from "./process-check";
+
+describe("parseWmicDate", () => {
+  it("parses a standard WMIC CreationDate", () => {
+    // 2026-03-07 09:12:12.123456
+    const result = parseWmicDate("20260307091212.123456");
+    expect(result).toBeDefined();
+    const date = new Date(result!);
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(2); // March = 2
+    expect(date.getDate()).toBe(7);
+    expect(date.getHours()).toBe(9);
+    expect(date.getMinutes()).toBe(12);
+    expect(date.getSeconds()).toBe(12);
+    expect(date.getMilliseconds()).toBe(123);
+  });
+
+  it("returns undefined for invalid format", () => {
+    expect(parseWmicDate("not-a-date")).toBeUndefined();
+    expect(parseWmicDate("")).toBeUndefined();
+    expect(parseWmicDate("2026030709121")).toBeUndefined();
+  });
+
+  it("handles midnight correctly", () => {
+    const result = parseWmicDate("20260101000000.000000");
+    expect(result).toBeDefined();
+    const date = new Date(result!);
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(0);
+    expect(date.getDate()).toBe(1);
+    expect(date.getHours()).toBe(0);
+  });
+});

--- a/src/process-check.ts
+++ b/src/process-check.ts
@@ -1,0 +1,99 @@
+import { execFile } from "node:child_process";
+
+/**
+ * Check whether a process is alive by PID + creation time.
+ *
+ * Returns:
+ *   true  — process exists and creation time matches
+ *   false — process does not exist, or PID was reused (creation time mismatch)
+ *   undefined — unable to determine (e.g. command failed)
+ */
+export async function isProcessAlive(
+  pid: number,
+  expectedCreatedAt: number,
+  toleranceMs = 5000,
+): Promise<boolean | undefined> {
+  if (process.platform !== "win32") {
+    return isProcessAliveUnix(pid, expectedCreatedAt, toleranceMs);
+  }
+  return isProcessAliveWin32(pid, expectedCreatedAt, toleranceMs);
+}
+
+async function isProcessAliveWin32(
+  pid: number,
+  expectedCreatedAt: number,
+  toleranceMs: number,
+): Promise<boolean | undefined> {
+  try {
+    const stdout = await execFileAsync("wmic", [
+      "process",
+      "where",
+      `ProcessId=${pid}`,
+      "get",
+      "CreationDate",
+      "/value",
+    ]);
+
+    const match = stdout.match(/CreationDate=(\d{14}\.\d+)([+-]\d+)/);
+    if (!match) return false; // process not found
+
+    const creationDate = parseWmicDate(match[1]);
+    if (creationDate == null) return undefined;
+
+    return Math.abs(creationDate - expectedCreatedAt) <= toleranceMs;
+  } catch {
+    return undefined;
+  }
+}
+
+async function isProcessAliveUnix(
+  pid: number,
+  expectedCreatedAt: number,
+  toleranceMs: number,
+): Promise<boolean | undefined> {
+  try {
+    // ps -o lstart= -p <pid> gives the start time
+    const stdout = await execFileAsync("ps", ["-o", "lstart=", "-p", String(pid)]);
+    const trimmed = stdout.trim();
+    if (!trimmed) return false;
+
+    const startTime = Date.parse(trimmed);
+    if (isNaN(startTime)) return undefined;
+
+    return Math.abs(startTime - expectedCreatedAt) <= toleranceMs;
+  } catch {
+    // ps fails if process doesn't exist (exit code 1)
+    return false;
+  }
+}
+
+/** Parse WMIC CreationDate format: 20260307091212.123456 → Unix ms */
+export function parseWmicDate(wmicDate: string): number | undefined {
+  // Format: YYYYMMDDHHmmss.ffffff
+  const m = wmicDate.match(
+    /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\.(\d+)$/,
+  );
+  if (!m) return undefined;
+
+  const [, year, month, day, hour, min, sec, frac] = m;
+  // Use local time (WMIC reports local time)
+  const date = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(min),
+    Number(sec),
+    Number(frac.slice(0, 3)), // ms from microseconds
+  );
+  return date.getTime();
+}
+
+function execFileAsync(cmd: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { timeout: 5000 }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(stdout);
+    });
+  });
+}

--- a/src/session-store.test.ts
+++ b/src/session-store.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SessionStore } from "./session-store";
 import type { SessionMapping } from "./types";
+
+// Mock process-check module
+vi.mock("./process-check", () => ({
+  isProcessAlive: vi.fn(),
+}));
+
+import { isProcessAlive } from "./process-check";
+const mockIsProcessAlive = vi.mocked(isProcessAlive);
 
 function createMapping(overrides: Partial<SessionMapping> = {}): SessionMapping {
   return {
@@ -28,6 +36,10 @@ function createStore(initial: SessionMapping[] = []): {
 }
 
 describe("SessionStore", () => {
+  beforeEach(() => {
+    mockIsProcessAlive.mockReset();
+  });
+
   it("starts empty", () => {
     const { store } = createStore();
     expect(store.getAll()).toEqual([]);
@@ -179,6 +191,65 @@ describe("SessionStore", () => {
 
     const { store } = createStore([legacy]);
     expect(store.getAll()[0].status).toBe("inactive");
+  });
+
+  describe("pruneDeadProcesses", () => {
+    it("marks dead processes as inactive", async () => {
+      mockIsProcessAlive.mockResolvedValue(false);
+      const { store } = createStore([
+        createMapping({ terminalName: "A", status: "active", pid: 1234, pidCreatedAt: Date.now() }),
+      ]);
+
+      const pruned = await store.pruneDeadProcesses("C:\\dev\\my-project");
+      expect(pruned).toBe(1);
+      expect(store.getAll()[0].status).toBe("inactive");
+    });
+
+    it("leaves alive processes as active", async () => {
+      mockIsProcessAlive.mockResolvedValue(true);
+      const { store } = createStore([
+        createMapping({ terminalName: "A", status: "active", pid: 1234, pidCreatedAt: Date.now() }),
+      ]);
+
+      const pruned = await store.pruneDeadProcesses("C:\\dev\\my-project");
+      expect(pruned).toBe(0);
+      expect(store.getAll()[0].status).toBe("active");
+    });
+
+    it("skips sessions without pid (safe side)", async () => {
+      const { store } = createStore([
+        createMapping({ terminalName: "A", status: "active" }),
+      ]);
+
+      const pruned = await store.pruneDeadProcesses("C:\\dev\\my-project");
+      expect(pruned).toBe(0);
+      expect(store.getAll()[0].status).toBe("active");
+      expect(mockIsProcessAlive).not.toHaveBeenCalled();
+    });
+
+    it("leaves process as active when check returns undefined", async () => {
+      mockIsProcessAlive.mockResolvedValue(undefined);
+      const { store } = createStore([
+        createMapping({ terminalName: "A", status: "active", pid: 1234, pidCreatedAt: Date.now() }),
+      ]);
+
+      const pruned = await store.pruneDeadProcesses("C:\\dev\\my-project");
+      expect(pruned).toBe(0);
+      expect(store.getAll()[0].status).toBe("active");
+    });
+
+    it("only prunes sessions for the given project", async () => {
+      mockIsProcessAlive.mockResolvedValue(false);
+      const { store } = createStore([
+        createMapping({ terminalName: "A", status: "active", pid: 1234, pidCreatedAt: Date.now(), projectPath: "C:\\dev\\project-a" }),
+        createMapping({ terminalName: "B", status: "active", pid: 5678, pidCreatedAt: Date.now(), projectPath: "C:\\dev\\project-b" }),
+      ]);
+
+      const pruned = await store.pruneDeadProcesses("C:\\dev\\project-a");
+      expect(pruned).toBe(1);
+      expect(store.getAll().find(m => m.terminalName === "A")!.status).toBe("inactive");
+      expect(store.getAll().find(m => m.terminalName === "B")!.status).toBe("active");
+    });
   });
 
   it("pruneExpired removes old entries and returns count", async () => {

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,5 +1,6 @@
 import type { SessionMapping } from "./types";
 import { normalizePath } from "./normalize-path";
+import { isProcessAlive } from "./process-check";
 
 const STORAGE_KEY = "claudeResurrectMappings";
 
@@ -122,6 +123,22 @@ export class SessionStore {
       ...this.mappings.slice(idx + 1),
     ];
     await this.persist(STORAGE_KEY, this.mappings);
+  }
+
+  /** Mark active sessions whose OS process has died as inactive */
+  async pruneDeadProcesses(projectPath: string): Promise<number> {
+    const actives = this.getActive(projectPath);
+    let pruned = 0;
+    for (const m of actives) {
+      if (m.pid == null) continue; // no pid recorded — skip (safe side)
+      const alive = await isProcessAlive(m.pid, m.pidCreatedAt ?? 0);
+      if (alive === false) {
+        await this.markInactive(m.terminalName, m.projectPath);
+        pruned++;
+      }
+      // alive === true or undefined → leave as active
+    }
+    return pruned;
   }
 
   /** Remove all expired mappings */

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export interface SessionMapping {
   readonly projectPath: string;
   readonly lastSeen: number; // Unix ms timestamp
   readonly status: SessionStatus;
+  readonly pid?: number;
+  readonly pidCreatedAt?: number; // Unix ms — approximate process creation time
 }
 
 /** Entry from ~/.claude/history.jsonl */


### PR DESCRIPTION
## Summary

- セッション復元前に OS プロセスの生存確認を行い、死んだセッションを `"inactive"` に落とす
- PID + 起動時刻の照合で PID 再利用を誤検出しない
- セッション起動時に `pid` / `pidCreatedAt` を `SessionMapping` に記録

Closes #48

## Test plan

- [x] `pruneDeadProcesses` のユニットテスト（dead/alive/no-pid/undefined/project-scoped）
- [x] `parseWmicDate` のユニットテスト
- [x] 既存テスト全通過（66 tests）
- [x] 型チェック通過
- [ ] 手動テスト: セッション起動 → プロセス kill → VS Code リロード → ゾンビが消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)