### PR TITLE
feat: add dumpState debug command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
       {
         "command": "claudeResurrect.showMenu",
         "title": "Claude Resurrect: Show Menu"
+      },
+      {
+        "command": "claudeResurrect.dumpState",
+        "title": "Claude Resurrect: Dump State (Debug)"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,6 +44,23 @@ export function activate(context: vscode.ExtensionContext): void {
       await showQuickPick(store, projectPath, updateStatusBar);
     }),
 
+    vscode.commands.registerCommand("claudeResurrect.dumpState", () => {
+      const channel = vscode.window.createOutputChannel("TS Recall Debug");
+      const all = store.getAll();
+      channel.appendLine(`=== TS Recall State Dump (${new Date().toISOString()}) ===`);
+      channel.appendLine(`Total mappings: ${all.length}`);
+      channel.appendLine("");
+      for (const m of all) {
+        channel.appendLine(`  ${m.status.padEnd(10)} ${m.terminalName}`);
+        channel.appendLine(`             session: ${m.sessionId.slice(0, 8)}…`);
+        channel.appendLine(`             project: ${m.projectPath}`);
+        channel.appendLine(`             pid: ${m.pid ?? "N/A"}  pidCreatedAt: ${m.pidCreatedAt ? new Date(m.pidCreatedAt).toLocaleString() : "N/A"}`);
+        channel.appendLine(`             lastSeen: ${new Date(m.lastSeen).toLocaleString()}`);
+        channel.appendLine("");
+      }
+      channel.show();
+    }),
+
     vscode.commands.registerCommand("claudeResurrect.newSession", async () => {
       if (!projectPath) {
         vscode.window.showWarningMessage(


### PR DESCRIPTION
## Summary

- `Claude Resurrect: Dump State (Debug)` コマンドを追加
- 全セッションの status, pid, pidCreatedAt, lastSeen を Output Channel に出力
- #48 のプロセス生存確認機能のデバッグ・動作確認用

## Test plan

- [x] 既存テスト全通過（66 tests）
- [ ] リリース後に実環境で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)