### PR TITLE
fix: replace wmic with PowerShell for process liveness check on Win11

### DIFF
--- a/src/process-check.test.ts
+++ b/src/process-check.test.ts
@@ -1,34 +1,27 @@
 import { describe, it, expect } from "vitest";
-import { parseWmicDate } from "./process-check";
+import { isProcessAlive } from "./process-check";
 
-describe("parseWmicDate", () => {
-  it("parses a standard WMIC CreationDate", () => {
-    // 2026-03-07 09:12:12.123456
-    const result = parseWmicDate("20260307091212.123456");
-    expect(result).toBeDefined();
-    const date = new Date(result!);
-    expect(date.getFullYear()).toBe(2026);
-    expect(date.getMonth()).toBe(2); // March = 2
-    expect(date.getDate()).toBe(7);
-    expect(date.getHours()).toBe(9);
-    expect(date.getMinutes()).toBe(12);
-    expect(date.getSeconds()).toBe(12);
-    expect(date.getMilliseconds()).toBe(123);
+describe("isProcessAlive", () => {
+  it("returns false for a PID that does not exist", async () => {
+    // PID 99999999 is extremely unlikely to exist
+    const result = await isProcessAlive(99999999, Date.now());
+    expect(result).toBe(false);
   });
 
-  it("returns undefined for invalid format", () => {
-    expect(parseWmicDate("not-a-date")).toBeUndefined();
-    expect(parseWmicDate("")).toBeUndefined();
-    expect(parseWmicDate("2026030709121")).toBeUndefined();
+  it("detects the current process as alive", async () => {
+    const pid = process.pid;
+    // Use a wide tolerance since pidCreatedAt is approximate
+    const result = await isProcessAlive(pid, Date.now(), 60_000);
+    // Should be true (alive) or undefined (unable to determine), not false
+    expect(result).not.toBe(false);
   });
 
-  it("handles midnight correctly", () => {
-    const result = parseWmicDate("20260101000000.000000");
-    expect(result).toBeDefined();
-    const date = new Date(result!);
-    expect(date.getFullYear()).toBe(2026);
-    expect(date.getMonth()).toBe(0);
-    expect(date.getDate()).toBe(1);
-    expect(date.getHours()).toBe(0);
+  it("returns false when creation time mismatches (PID reuse)", async () => {
+    const pid = process.pid;
+    // Pretend the process was created in 2020 — should mismatch
+    const result = await isProcessAlive(pid, new Date("2020-01-01").getTime(), 5000);
+    if (result !== undefined) {
+      expect(result).toBe(false);
+    }
   });
 });

--- a/src/process-check.ts
+++ b/src/process-check.ts
@@ -25,22 +25,22 @@ async function isProcessAliveWin32(
   toleranceMs: number,
 ): Promise<boolean | undefined> {
   try {
-    const stdout = await execFileAsync("wmic", [
-      "process",
-      "where",
-      `ProcessId=${pid}`,
-      "get",
-      "CreationDate",
-      "/value",
+    // PowerShell: get process start time as Unix ms (wmic removed in Win11)
+    const script = `try { (Get-Process -Id ${pid}).StartTime.ToUniversalTime().Subtract([datetime]'1970-01-01').TotalMilliseconds } catch { 'NOT_FOUND' }`;
+    const stdout = await execFileAsync("powershell.exe", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      script,
     ]);
 
-    const match = stdout.match(/CreationDate=(\d{14}\.\d+)([+-]\d+)/);
-    if (!match) return false; // process not found
+    const trimmed = stdout.trim();
+    if (!trimmed || trimmed === "NOT_FOUND") return false;
 
-    const creationDate = parseWmicDate(match[1]);
-    if (creationDate == null) return undefined;
+    const startTimeMs = Number(trimmed);
+    if (isNaN(startTimeMs)) return undefined;
 
-    return Math.abs(creationDate - expectedCreatedAt) <= toleranceMs;
+    return Math.abs(startTimeMs - expectedCreatedAt) <= toleranceMs;
   } catch {
     return undefined;
   }
@@ -67,27 +67,6 @@ async function isProcessAliveUnix(
   }
 }
 
-/** Parse WMIC CreationDate format: 20260307091212.123456 → Unix ms */
-export function parseWmicDate(wmicDate: string): number | undefined {
-  // Format: YYYYMMDDHHmmss.ffffff
-  const m = wmicDate.match(
-    /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\.(\d+)$/,
-  );
-  if (!m) return undefined;
-
-  const [, year, month, day, hour, min, sec, frac] = m;
-  // Use local time (WMIC reports local time)
-  const date = new Date(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(min),
-    Number(sec),
-    Number(frac.slice(0, 3)), // ms from microseconds
-  );
-  return date.getTime();
-}
 
 function execFileAsync(cmd: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Windows 11 で `wmic` が削除されたため、`pruneDeadProcesses` が常に判定不能（`undefined`）を返し、ゾンビセッションが active のまま残り続けていた
- `isProcessAliveWin32` を `wmic` → `powershell.exe (Get-Process)` に差し替え
- 不要になった `parseWmicDate` を削除し、テストを `isProcessAlive` の実動作テストに置き換え

## Test plan

- [x] `npm run typecheck` パス
- [x] `npm run test` 66件パス
- [x] `npm run compile` パス
- [ ] Win11 で F5 デバッグ → 新規セッション作成 → VSCode 再起動 → ゾンビが active に残らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)