### PR TITLE
fix: run autoRestore before pruneDeadProcesses (#57)

### DIFF
--- a/docs/planning/2026-03-12-issue-57-f5-test-plan.md
+++ b/docs/planning/2026-03-12-issue-57-f5-test-plan.md
@@ -1,0 +1,31 @@
+# Issue #57: F5 デバッグ検証手順
+
+## 前提
+
+- F5 で Extension Development Host（以下 EDH）を起動済み
+
+## テスト 1: Full Close → Restart での autoRestore
+
+1. F5 で EDH を起動する
+2. コマンドパレット → `Terminal Session Recall: New Session` を実行する
+3. Claude CLI が起動したら、何か一言会話する（例: `hello`）。セッションファイルにデータが書き込まれる必要があるため
+4. ステータスバーが `TS Recall: 1 live` に変わることを確認する
+5. **EDH の VSCode インスタンスを終了する**（Alt+F4 または ファイル → ウィンドウを閉じる）
+6. F5 で EDH を再度起動する
+7. 「Restored 1 interrupted session(s).」の通知が表示されることを確認する
+8. ステータスバーが `TS Recall: 1 live` であることを確認する
+9. 復元されたターミナルのゴミ箱アイコンをクリックして閉じる
+10. ステータスバーが `TS Recall: 0 live` であることを確認する
+
+## テスト 2: Reload Window で二重生成しないこと
+
+1. F5 で EDH を起動する
+2. コマンドパレット → `Terminal Session Recall: New Session` を実行する
+3. Claude CLI が起動したら、何か一言会話する（例: `hello`）
+4. ステータスバーが `TS Recall: 1 live` に変わることを確認する
+5. コマンドパレット → `Developer: Reload Window` を実行する
+6. EDH がリロードされるのを待つ
+7. ターミナルパネルに同じセッションのターミナルが 1 つだけ存在することを確認する（二重生成なし）
+8. ステータスバーが `TS Recall: 1 live` であることを確認する
+9. ターミナルのゴミ箱アイコンをクリックして閉じる
+10. ステータスバーが `TS Recall: 0 live` であることを確認する

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,13 +109,16 @@ export function activate(context: vscode.ExtensionContext): void {
     // 14日（336時間）超過のマッピングを globalState から削除
     void store.pruneExpired(336);
 
-    // Prune sessions whose OS process has died, then auto-restore
-    void store.pruneDeadProcesses(path).then(() => {
-      updateStatusBar();
-      if (autoRestore) {
-        void autoRestoreSessions(store, path, updateStatusBar, terminalSessionMap);
-      }
-    });
+    // autoRestore を先に実行し、その後に dead process をクリーンアップ
+    const afterRestore = autoRestore
+      ? autoRestoreSessions(store, path, updateStatusBar, terminalSessionMap)
+      : Promise.resolve();
+
+    void afterRestore.then(() =>
+      store.pruneDeadProcesses(path).then(() => {
+        updateStatusBar();
+      })
+    );
   };
 
   if (projectPath) {


### PR DESCRIPTION
## Summary

- `initProject` 内で `autoRestoreSessions` を `pruneDeadProcesses` より先に実行するよう順序を変更
- Full Close → Restart 時に dead PID の active セッションが復元前に inactive 化される問題を修正
- F5 デバッグ検証手順を `docs/planning/` に追加

## Test plan

- [x] テスト 1: Full Close → Restart で autoRestore が動作すること（通知表示・ステータスバー確認）
- [x] テスト 2: Reload Window で二重生成しないこと
- [x] `npm run typecheck && npm run test && npm run compile` パス

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)