### PR TITLE
fix: WSL2環境でautoRestore時のシェル構文エラーを修正

### DIFF
--- a/docs/planning/2026-03-14-wsl2-sendtext-race.md
+++ b/docs/planning/2026-03-14-wsl2-sendtext-race.md
@@ -1,0 +1,54 @@
+# WSL2 環境での sendText 競合によるシェルエラー
+
+## 現象
+
+WSL2 環境で autoRestore が実行されると、ときおり以下のエラーが発生する：
+
+```
+/bin/bash: -c: line 1: unexpected EOF while looking for matching `''
+```
+
+毎回ではなく、不定期に発生する。
+
+## 原因分析
+
+`resumeSession` / `startNewSession` で `createTerminal` 直後に `sendText` を呼んでいる：
+
+```typescript
+// extension.ts:229-234
+const terminal = vscode.window.createTerminal({
+  name: terminalName,
+  cwd: projectPath,
+  isTransient: true,
+});
+terminal.sendText(`${getClaudePath()} --resume ${sessionId}`);
+```
+
+WSL2 のターミナルはネイティブより起動が遅いため、bash がまだ `.bashrc` 等の初期化スクリプトを実行中に `sendText` のコマンド文字列が stdin に流れ込むことがある。`.bashrc` 内のシングルクォートを含む行のパース中にコマンドが混入すると、bash がクォートの対応を誤認し `unexpected EOF while looking for matching '` となる。
+
+タイミング依存のため再現性が不安定。
+
+## 修正方針
+
+`sendText` の前に VS Code の Shell Integration API を使い、シェルの準備完了を待つ。
+
+```mermaid
+flowchart TD
+    B1[createTerminal] --> B2[terminal.show]
+    B2 --> B3{"shellIntegration\nready を待つ"}
+    B3 -->|ready| B4["sendText: claude --resume ..."]
+    B3 -->|タイムアウト 5s| B4
+```
+
+### ヘルパー関数
+
+- `terminal.shellIntegration` が既に存在 → 即座に `sendText`
+- 未存在 → `onDidChangeTerminalShellIntegration` イベントを待つ
+- 5 秒以内に来なければフォールバックとして `sendText`（shellIntegration 無効環境への対応）
+
+### 変更箇所
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `extension.ts` | シェル ready を待つヘルパー関数を追加 |
+| `extension.ts` | `resumeSession` と `startNewSession` の `sendText` 呼び出しをヘルパー経由に変更 |

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,7 +183,7 @@ async function startNewSession(
     isTransient: true,
   });
   terminal.show();
-  terminal.sendText(`${getClaudePath()} --session-id ${sessionId}`);
+  sendTextWhenReady(terminal, `${getClaudePath()} --session-id ${sessionId}`);
   terminalSessionMap.set(terminal, sessionId);
 
   // Record PID for liveness checking on next startup
@@ -231,7 +231,7 @@ async function resumeSession(
     cwd: projectPath,
     isTransient: true,
   });
-  terminal.sendText(`${getClaudePath()} --resume ${sessionId}`);
+  sendTextWhenReady(terminal, `${getClaudePath()} --resume ${sessionId}`);
   terminal.show();
   terminalSessionMap.set(terminal, sessionId);
 
@@ -443,7 +443,7 @@ async function showQuickPick(
         cwd: projectPath,
         isTransient: true,
       });
-      terminal.sendText(`${getClaudePath()} --continue`);
+      sendTextWhenReady(terminal, `${getClaudePath()} --continue`);
       terminal.show();
       break;
     }
@@ -483,6 +483,36 @@ async function showQuickPick(
       }
       break;
   }
+}
+
+/**
+ * Wait for shell integration to become ready, then send text.
+ * Falls back to raw sendText after timeout (for environments without shell integration).
+ */
+function sendTextWhenReady(
+  terminal: vscode.Terminal,
+  text: string,
+  timeoutMs = 5000,
+): void {
+  if (terminal.shellIntegration) {
+    terminal.sendText(text);
+    return;
+  }
+
+  const disposable = vscode.window.onDidChangeTerminalShellIntegration(
+    ({ terminal: readyTerminal }) => {
+      if (readyTerminal === terminal) {
+        clearTimeout(timer);
+        disposable.dispose();
+        terminal.sendText(text);
+      }
+    },
+  );
+
+  const timer = setTimeout(() => {
+    disposable.dispose();
+    terminal.sendText(text);
+  }, timeoutMs);
 }
 
 function formatAge(timestamp: number): string {


### PR DESCRIPTION
## Summary

- `createTerminal` 直後の `sendText` が、WSL2 のようにシェル起動が遅い環境で `.bashrc` 初期化と競合し、ときおり構文エラーを起こしていた
- Shell Integration API（`onDidChangeTerminalShellIntegration`）でシェル ready を待ってから `sendText` するよう修正
- 5秒タイムアウトのフォールバックで shellIntegration 無効環境にも対応

Closes #59

## Test plan

- [ ] WSL2 環境で F5 デバッグ起動し、autoRestore が構文エラーなく復元されることを確認
- [ ] ネイティブ環境（Windows / macOS）で既存動作に影響がないことを確認
- [ ] shellIntegration が無効な環境でもタイムアウト後にコマンドが送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)