### PR TITLE
fix: prune dead processes before auto-restore

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,16 +114,14 @@ export function activate(context: vscode.ExtensionContext): void {
     // 14日（336時間）超過のマッピングを globalState から削除
     void store.pruneExpired(336);
 
-    // autoRestore を先に実行し、その後に dead process をクリーンアップ
-    const afterRestore = autoRestore
-      ? autoRestoreSessions(store, path, updateStatusBar, terminalSessionMap)
-      : Promise.resolve();
-
-    void afterRestore.then(() =>
-      store.pruneDeadProcesses(path).then(() => {
-        updateStatusBar();
-      })
-    );
+    // dead process を先にクリーンアップしてから autoRestore
+    // exit 済みセッションの誤復元を防ぐ
+    void store.pruneDeadProcesses(path).then(() => {
+      if (autoRestore) {
+        void autoRestoreSessions(store, path, updateStatusBar, terminalSessionMap);
+      }
+      updateStatusBar();
+    });
   };
 
   if (projectPath) {


### PR DESCRIPTION
## Summary
- `pruneDeadProcesses` を `autoRestoreSessions` の前に実行するよう順序を変更
- `exit` でプロセス終了済みだがターミナルパネルが残っていたセッションが、VSCode リスタート時に誤って復元される問題を修正

## 背景
ユーザーが `exit` を実行してもターミナルパネルが開いたままの場合、`onDidCloseTerminal` が発火せずセッションは `active` のまま残る。従来は autoRestore → pruneDeadProcesses の順だったため、死んだプロセスのセッションも復元されていた。

## Test plan
- [x] `npm run typecheck` pass
- [x] `npm run test` pass (77 tests)
- [x] `npm run compile` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)