### PR TITLE
fix: await autoRestoreSessions before updating status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,9 +116,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // dead process を先にクリーンアップしてから autoRestore
     // exit 済みセッションの誤復元を防ぐ
-    void store.pruneDeadProcesses(path).then(() => {
+    void store.pruneDeadProcesses(path).then(async () => {
       if (autoRestore) {
-        void autoRestoreSessions(store, path, updateStatusBar, terminalSessionMap);
+        await autoRestoreSessions(store, path, updateStatusBar, terminalSessionMap);
       }
       updateStatusBar();
     });


### PR DESCRIPTION
## Summary
- `autoRestoreSessions` を `await` してからステータスバーを更新するよう修正
- 起動時にセッション数が一瞬 0 と表示される問題を解消

## 背景
#82 で `pruneDeadProcesses` → `autoRestore` の順序に変更した際、`autoRestoreSessions` が fire-and-forget (`void`) のままだったため、復元完了前に `updateStatusBar()` が走っていた。

## Test plan
- [x] `npm run typecheck` pass
- [x] `npm run test` pass (77 tests)
- [x] `npm run compile` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)