### PR TITLE
chore: publish v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.8
+
+- Revert: WSL2 対策の sendTextWhenReady 遅延処理を削除 — 根本原因は起動スクリプトのクォーテーション差異であり、遅延は不要かつ動作を阻害していた (#77)
+
 ## 1.0.7
 
 - Docs: README にデモ GIF を追加（Marketplace ストアページ用）

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "terminal-session-recall",
   "displayName": "Terminal Session Recall",
   "description": "Automatically resume Claude Code CLI sessions after VSCode restart",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publisher": "orange-creatives",
   "license": "MIT",
   "icon": "art/icon.png",


### PR DESCRIPTION
## Summary
- バージョン 1.0.8 のリリース準備（package.json + CHANGELOG.md）

マージ後に Marketplace パブリッシュを実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)