### PR TITLE
feat: handle Claude CLI v2.1.90+ resume dialog (beta)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
 version: 2
 updates:
+  # npm セキュリティ更新のみ（2026-04-05 変更）
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 3
     labels:
-      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Claude Resurrect — Claude Code 設定
 
+> 汎用ルール（行動規範、git運用、Dependabotポリシー、環境注意事項等）は `~/.claude/CLAUDE.md` を参照（chezmoi管理）。
+
 ## プロジェクト概要
 
 VSCode 再起動時に Claude Code CLI セッションを自動復元する拡張機能。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > Unofficial VSCode extension — Automatically restore Claude Code CLI sessions after restart
 
+> **v1.1.0-beta**: This version adds urgent support for the resume dialog introduced in Claude CLI v2.1.90+. Because the CLI change was not accompanied by a public API, this extension detects the dialog via terminal output matching — behavior may be fragile. Please report issues at [GitHub Issues](https://github.com/orangewk/terminal-session-recall/issues).
+
+> **v1.1.0-beta**: このバージョンは Claude CLI v2.1.90+ で追加された resume ダイアログへの緊急対応です。CLI 側に公開 API がないため、ターミナル出力のパターンマッチで検知しており、動作が不安定になる可能性があります。不具合は [GitHub Issues](https://github.com/orangewk/terminal-session-recall/issues) へ報告してください。
+
 ![Demo](art/demo.gif)
 
 ![UI Overview](art/ui-overview.png)
@@ -25,6 +29,7 @@
 | claudeResurrect.autoRestore | true | Automatically restore interrupted sessions on startup |
 | claudeResurrect.autoRestoreMaxAge | 24 | Maximum age (hours) of sessions to auto-restore |
 | claudeResurrect.claudePath | "claude" | Path to the Claude CLI executable |
+| claudeResurrect.resumeDialogAction | "summary" | How to handle CLI's large-session resume dialog: `summary`, `full`, or `ask` |
 
 ## Limitations
 
@@ -84,6 +89,7 @@ This extension does NOT:
 | claudeResurrect.autoRestore | true | 起動時に中断セッションを自動復元 |
 | claudeResurrect.autoRestoreMaxAge | 24 | 自動復元の最大経過時間（時間） |
 | claudeResurrect.claudePath | "claude" | Claude CLI のパス |
+| claudeResurrect.resumeDialogAction | "summary" | CLI の大セッション resume ダイアログへの対応: `summary`, `full`, `ask` |
 
 ### 制限事項
 

--- a/docs/planning/2026-04-05-resume-dialog-handling--wip.md
+++ b/docs/planning/2026-04-05-resume-dialog-handling--wip.md
@@ -1,0 +1,130 @@
+# Claude CLI resume ダイアログ対応
+
+## 要件の再確認
+
+Claude CLI v2.1.90+ で、大きいセッションの `--resume` / `--continue` 時にインタラクティブダイアログが表示されるようになった。
+
+```
+This session is 7d 4h old and 101k tokens.
+
+Resuming the full session will consume a substantial portion of your usage
+limits. We recommend resuming from a summary.
+
+❯ 1. Resume from summary (recommended)
+  2. Resume full session as-is
+  3. Don't ask me again
+```
+
+- 数字キー `1`, `2`, `3` で選択可能（`sendText("1")` で動作確認済み）
+- `~/.claude.json` の `resumeReturnDismissed: true` で非表示にできる
+- 閾値不明（トークン数 + 経過時間ベース。100k tokens / 7d で表示確認）
+
+### 問題
+
+本拡張は `terminal.sendText("claude --resume <id>")` で復元するが、ダイアログへの応答機能がない。
+→ 入力待ちブロック → **CPU 25% 食い続ける**
+
+## 技術調査
+
+### ターミナル出力の読み取り方法
+
+| API | 利用可否 | 備考 |
+|-----|---------|------|
+| `TerminalShellIntegration.executeCommand()` + `read()` | ✅ 推奨 | Shell Integration 有効時のみ。出力ストリームを async iterable で読める |
+| `terminal.sendText()` | 現状使用中 | 出力を読めない。ダイアログ対応不可 |
+
+**方針**: `shellIntegration.executeCommand()` に移行する。Shell Integration が無効な環境では `sendText()` にフォールバックし、タイムアウトで保護する。
+
+### executeCommand + read の流れ
+
+```typescript
+// Shell Integration 待ち
+window.onDidChangeTerminalShellIntegration(({ terminal, shellIntegration }) => {
+  const execution = shellIntegration.executeCommand(`claude --resume ${sessionId}`);
+  const stream = execution.read();
+  for await (const data of stream) {
+    if (data.includes("Resume from summary")) {
+      // ダイアログ検知 → 応答
+      terminal.sendText("1"); // or "2"
+      break;
+    }
+  }
+});
+```
+
+### フォールバック（Shell Integration なし）
+
+```typescript
+setTimeout(() => {
+  if (!terminal.shellIntegration) {
+    terminal.sendText(`claude --resume ${sessionId}`);
+    // ダイアログ対応不可 → タイムアウト後に警告
+  }
+}, 3000);
+```
+
+## 実装計画
+
+### Phase 1: ターミナル出力監視 + ダイアログ自動応答
+
+**変更ファイル**: `src/extension.ts`
+
+1. `resumeSession()` を `executeCommand()` ベースに書き換え
+   - Shell Integration 待ち（`onDidChangeTerminalShellIntegration`）
+   - タイムアウト付き（3秒で fallback to `sendText`）
+2. `read()` ストリームでダイアログ検知
+   - 検知パターン: `"Resume from summary"` を含む出力
+   - autoRestore 時: 設定に従い `sendText("1")` or `sendText("2")`
+   - 手動 resume 時（`"ask"` 設定）: VSCode QuickPick を表示 → ユーザー選択 → `sendText`
+3. `continue` アクション（QuickPick の "Continue Last"）にも同様の監視を追加
+
+### Phase 2: 設定追加
+
+**変更ファイル**: `package.json`
+
+```json
+"claudeResurrect.resumeDialogAction": {
+  "type": "string",
+  "enum": ["summary", "full", "ask"],
+  "default": "summary",
+  "description": "How to handle Claude CLI's resume dialog: 'summary' auto-selects Resume from summary, 'full' auto-selects Resume full session, 'ask' shows a VS Code picker"
+}
+```
+
+### Phase 3: 堅牢性
+
+CLI 仕様変更（文字列変更・ダイアログ廃止）時にハングしないための保護:
+
+1. **ストリーム読み取りタイムアウト**: `read()` 開始から N 秒以内にダイアログ検知できなければ「ダイアログなし」と判断して監視終了
+   - ダイアログが廃止された場合 → タイムアウトで正常終了
+   - 文字列が変わった場合 → 同上（ハングしない）
+2. **Shell Integration フォールバック**: WSL2 等で Shell Integration が効かない環境では `sendText()` にフォールバック
+3. **検知パターンの緩さ**: 完全一致ではなく部分一致（`"Resume from summary"` or `"resume"` + `"summary"` の組み合わせ）
+4. **ログ出力**: 検知・応答・タイムアウトすべてログに記録
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/extension.ts` | `resumeSession()` の実行方式変更、ダイアログ監視ロジック追加 |
+| `package.json` | `claudeResurrect.resumeDialogAction` 設定追加 |
+| `src/types.ts` | 必要に応じて型追加 |
+
+## リスク
+
+| レベル | リスク | 対策 |
+|--------|--------|------|
+| **HIGH** | Shell Integration が有効にならない環境（WSL2等）ではダイアログ対応不可 | sendText フォールバック + タイムアウト保護。README で注記 |
+| **MEDIUM** | CLI のダイアログ文言が変わる | 部分一致検知 + タイムアウトで保護。ハングはしない |
+| **MEDIUM** | `executeCommand()` への移行で既存の動作が変わる | Shell Integration 待ちのタイムアウトで従来の sendText にフォールバック |
+| **LOW** | `read()` ストリームが大量データを返す | ダイアログ検知後すぐ break。タイムアウトでも打ち切り |
+
+## 複雑度: 中
+
+`executeCommand` + `read` への移行が主な変更。ダイアログ検知ロジック自体はシンプル。
+
+## 確認事項（ユーザーへ）
+
+1. **デフォルト値**: `resumeDialogAction` のデフォルトは `"summary"` でよいか？
+2. **タイムアウト秒数**: ダイアログ検知のタイムアウトは何秒が適切か？（提案: 15秒 — CLI の起動 + workspace trust 等を考慮）
+3. **Shell Integration 前提への移行**: `engines.vscode` は現在 `^1.96.0`。`executeCommand` は 1.93+ で使用可能なので問題なし

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "terminal-session-recall",
   "displayName": "Terminal Session Recall",
   "description": "Automatically resume Claude Code CLI sessions after VSCode restart",
-  "version": "1.0.8",
+  "version": "1.1.0-beta.1",
   "publisher": "orange-creatives",
   "license": "MIT",
   "icon": "art/icon.png",
@@ -61,6 +61,17 @@
           "type": "string",
           "default": "claude",
           "description": "Path to the Claude CLI executable"
+        },
+        "claudeResurrect.resumeDialogAction": {
+          "type": "string",
+          "enum": ["summary", "full", "ask"],
+          "default": "summary",
+          "enumDescriptions": [
+            "Auto-select 'Resume from summary' (saves tokens)",
+            "Auto-select 'Resume full session as-is'",
+            "Show a VS Code picker to let you choose each time"
+          ],
+          "description": "How to handle Claude CLI's large-session resume dialog (v2.1.90+)"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,6 +205,7 @@ async function resumeSession(
   projectPath: string,
   onUpdate: () => void,
   terminalSessionMap: Map<vscode.Terminal, string>,
+  isAutoRestore = false,
 ): Promise<void> {
   if (!isValidSessionId(sessionId)) {
     log.warn(`resumeSession: invalid session ID rejected: ${sessionId.slice(0, 20)}`);
@@ -231,12 +232,16 @@ async function resumeSession(
   };
   await store.upsert(mapping);
 
+  const config = vscode.workspace.getConfiguration("claudeResurrect");
+  const action = config.get<ResumeDialogAction>("resumeDialogAction", "summary");
+  const command = `${getClaudePath()} --resume ${sessionId}`;
+
   const terminal = vscode.window.createTerminal({
     name: terminalName,
     cwd: projectPath,
     isTransient: true,
   });
-  terminal.sendText(`${getClaudePath()} --resume ${sessionId}`);
+  executeClaudeCommand(terminal, command, { action, isAutoRestore });
   terminal.show();
   terminalSessionMap.set(terminal, sessionId);
 
@@ -275,7 +280,7 @@ async function autoRestoreSessions(
 
     const info = readSessionDisplayInfo(projectPath, mapping.sessionId);
     const displayName = resolveDisplayName(info, mapping.sessionId);
-    await resumeSession(store, mapping.sessionId, displayName, projectPath, onUpdate, terminalSessionMap);
+    await resumeSession(store, mapping.sessionId, displayName, projectPath, onUpdate, terminalSessionMap, true);
     restored++;
   }
 
@@ -468,12 +473,14 @@ async function showQuickPick(
       break;
     }
     case "continue": {
+      const config = vscode.workspace.getConfiguration("claudeResurrect");
+      const action = config.get<ResumeDialogAction>("resumeDialogAction", "summary");
       const terminal = vscode.window.createTerminal({
         name: "TS Recall: continue",
         cwd: projectPath,
         isTransient: true,
       });
-      terminal.sendText(`${getClaudePath()} --continue`);
+      executeClaudeCommand(terminal, `${getClaudePath()} --continue`, { action, isAutoRestore: false });
       terminal.show();
       break;
     }
@@ -512,6 +519,126 @@ async function showQuickPick(
         await resumeSession(store, d.sessionId, displayName, projectPath, onUpdate, terminalSessionMap);
       }
       break;
+  }
+}
+
+// --- Resume dialog detection ---
+
+type ResumeDialogAction = "summary" | "full" | "ask";
+
+/** Pattern to detect the Claude CLI resume dialog (v2.1.90+). Uses partial match for resilience. */
+const RESUME_DIALOG_PATTERN = /Resume from summary/i;
+
+/**
+ * Execute a claude command in the terminal and watch for the resume dialog.
+ *
+ * Strategy:
+ * 1. If Shell Integration is available → executeCommand + read() stream for output detection
+ * 2. Fallback → sendText (no dialog detection, protected by timeout)
+ *
+ * Returns a Disposable that cleans up the watcher.
+ */
+function executeClaudeCommand(
+  terminal: vscode.Terminal,
+  command: string,
+  options: {
+    action: ResumeDialogAction;
+    isAutoRestore: boolean;
+  },
+): vscode.Disposable {
+  const DIALOG_TIMEOUT_MS = 15_000;
+  const disposables: vscode.Disposable[] = [];
+  let dialogHandled = false;
+
+  const handleDialog = async (
+    sendResponse: (text: string) => void,
+  ): Promise<void> => {
+    if (dialogHandled) return;
+    dialogHandled = true;
+
+    const effectiveAction =
+      options.action === "ask" && options.isAutoRestore
+        ? "summary" // autoRestore 中に ask は不適切 → summary にフォールバック
+        : options.action;
+
+    if (effectiveAction === "ask") {
+      const choice = await vscode.window.showQuickPick(
+        [
+          { label: "$(sparkle) Resume from summary", description: "Saves tokens (recommended)", value: "1" },
+          { label: "$(file) Resume full session", description: "Load entire context as-is", value: "2" },
+        ],
+        { placeHolder: "Claude CLI: How do you want to resume this session?" },
+      );
+      // If user cancels the picker, default to summary
+      sendResponse(choice?.value ?? "1");
+    } else {
+      sendResponse(effectiveAction === "summary" ? "1" : "2");
+    }
+  };
+
+  // Try Shell Integration first
+  if (terminal.shellIntegration) {
+    log.info("executeClaudeCommand: using shellIntegration.executeCommand");
+    const execution = terminal.shellIntegration.executeCommand(command);
+    watchExecutionStream(execution, terminal, handleDialog, DIALOG_TIMEOUT_MS, disposables);
+  } else {
+    // Wait for Shell Integration to become available, with timeout fallback
+    const SI_WAIT_MS = 3_000;
+    let resolved = false;
+
+    const siListener = vscode.window.onDidChangeTerminalShellIntegration(({ terminal: t, shellIntegration }) => {
+      if (t !== terminal || resolved) return;
+      resolved = true;
+      siListener.dispose();
+      log.info("executeClaudeCommand: shellIntegration became available");
+      const execution = shellIntegration.executeCommand(command);
+      watchExecutionStream(execution, terminal, handleDialog, DIALOG_TIMEOUT_MS, disposables);
+    });
+    disposables.push(siListener);
+
+    setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      siListener.dispose();
+      log.info("executeClaudeCommand: shellIntegration timeout, falling back to sendText");
+      terminal.sendText(command);
+      // No dialog detection possible with sendText — just log the limitation
+    }, SI_WAIT_MS);
+  }
+
+  return vscode.Disposable.from(...disposables);
+}
+
+async function watchExecutionStream(
+  execution: vscode.TerminalShellExecution,
+  terminal: vscode.Terminal,
+  onDialogDetected: (sendResponse: (text: string) => void) => Promise<void>,
+  timeoutMs: number,
+  disposables: vscode.Disposable[],
+): Promise<void> {
+  let detected = false;
+
+  const timer = setTimeout(() => {
+    if (!detected) {
+      log.info("watchExecutionStream: timeout — no dialog detected, assuming clean resume");
+    }
+  }, timeoutMs);
+
+  try {
+    for await (const data of execution.read()) {
+      if (detected) continue; // drain remaining data
+      if (RESUME_DIALOG_PATTERN.test(data)) {
+        detected = true;
+        clearTimeout(timer);
+        log.info("watchExecutionStream: resume dialog detected");
+        await onDialogDetected((text) => terminal.sendText(text));
+      }
+    }
+  } catch {
+    // Stream ended or terminal closed — safe to ignore
+    log.info("watchExecutionStream: stream ended");
+  } finally {
+    clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
## Summary

- Claude CLI v2.1.90+ added an interactive resume dialog for large sessions that blocks auto-restore and causes CPU spikes
- Detect the dialog via Shell Integration `executeCommand` + `read()` stream
- Auto-respond based on new `resumeDialogAction` setting (`summary` / `full` / `ask`)
- Timeout protection ensures no hang if CLI changes the dialog text or removes it
- Version bumped to `1.1.0-beta.1` — fragile CLI coupling, not fully integration-tested

## Test plan

- [ ] F5 debug: manual resume of a large session (100k+ tokens) with `resumeReturnDismissed` unset
- [ ] Verify dialog detection and auto-response in TS Recall output log
- [ ] Verify `"ask"` mode shows VS Code QuickPick
- [ ] Verify small sessions (no dialog) pass through cleanly after timeout
- [ ] Verify Shell Integration fallback to sendText works

🤖 Generated with [Claude Code](https://claude.com/claude-code)