### PR TITLE
docs: declare maintenance paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > Unofficial VSCode extension — Automatically restore Claude Code CLI sessions after restart
 
-> **v1.1.0-beta**: This version adds urgent support for the resume dialog introduced in Claude CLI v2.1.90+. Because the CLI change was not accompanied by a public API, this extension detects the dialog via terminal output matching — behavior may be fragile. Please report issues at [GitHub Issues](https://github.com/orangewk/terminal-session-recall/issues).
+> **Maintenance paused (2026-04):** Claude CLI ships breaking changes too frequently for this extension to keep up. No further updates are planned for the foreseeable future, and current versions may break on newer CLI releases. Use at your own risk.
 
-> **v1.1.0-beta**: このバージョンは Claude CLI v2.1.90+ で追加された resume ダイアログへの緊急対応です。CLI 側に公開 API がないため、ターミナル出力のパターンマッチで検知しており、動作が不安定になる可能性があります。不具合は [GitHub Issues](https://github.com/orangewk/terminal-session-recall/issues) へ報告してください。
+> **メンテナンス休止中 (2026-04):** Claude CLI の破壊的変更の頻度が高く、追随を断念しました。当面更新の予定はなく、新しい CLI バージョンでは動作しなくなる可能性があります。ご利用は自己責任でお願いします。
 
 ![Demo](art/demo.gif)
 


### PR DESCRIPTION
## Summary
- Claude CLI の破壊的変更の頻度が高く、追随を断念した旨を README 冒頭で宣言
- v1.1.0-beta の一時注記を差し替え（EN / JA 両方）

## Test plan
- [x] README の該当箇所が「Maintenance paused / メンテナンス休止中」に置き換わっていること
- [ ] Marketplace の表示に反映されるのは次回 publish 時（今回はコードと README のみで publish しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)